### PR TITLE
SF-028 タグ登録APIの実装

### DIFF
--- a/api/src/app/Adapter/Gateway/TagRepository.php
+++ b/api/src/app/Adapter/Gateway/TagRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapter\Gateway;
+
+use App\Models\Tag;
+use Domain\Repository\TagRepositoryInterface;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+/**
+ * TagRepository class
+ */
+final class TagRepository implements TagRepositoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function findByName(string $name): ?Tag
+    {
+        return Tag::where('name', $name)->first();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(string $name): Tag
+    {
+        $tag = new Tag();
+        $tag->uuid = (string) Str::uuid();
+        $tag->name = $name;
+
+        try {
+            $tag->save();
+        } catch (RuntimeException $exception) {
+            throw $exception;
+        }
+
+        return $tag;
+    }
+}

--- a/api/src/app/Adapter/Presenter/Tag/StoreTagPresenter.php
+++ b/api/src/app/Adapter/Presenter/Tag/StoreTagPresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Adapter\Presenter\Tag;
+
+use App\Models\Tag;
+
+/**
+ * StoreTagPresenter class
+ */
+final class StoreTagPresenter
+{
+    /**
+     * コンストラクタ
+     *
+     * @param Tag $tag
+     */
+    public function __construct(private Tag $tag)
+    {
+    }
+
+    /**
+     * 配列に変換
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->tag->id,
+            'name' => $this->tag->name,
+        ];
+    }
+}

--- a/api/src/app/Http/Controllers/Tag/Store.php
+++ b/api/src/app/Http/Controllers/Tag/Store.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Tag;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Tag\StoreRequest;
+use Domain\UseCase\Tag\StoreTag;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Store class
+ */
+final class Store extends Controller
+{
+    /**
+     * タグを登録する
+     *
+     * @param StoreTag $useCase
+     * @param StoreRequest $request
+     * @return JsonResponse
+     */
+    public function __invoke(
+        StoreTag $useCase,
+        StoreRequest $request
+    ): JsonResponse {
+        return response()->json($useCase($request->input('name')));
+    }
+}

--- a/api/src/app/Http/Requests/Questionnaire/StoreRequest.php
+++ b/api/src/app/Http/Requests/Questionnaire/StoreRequest.php
@@ -73,7 +73,7 @@ final class StoreRequest extends FormRequest
                 'min:' . DisplayOrder::MIN_VALUE,
             ],
             'tags' => [
-                'required',
+                'nullable',
                 'array',
             ],
             'tags.*.id' => [

--- a/api/src/app/Http/Requests/Tag/StoreRequest.php
+++ b/api/src/app/Http/Requests/Tag/StoreRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Tag;
+
+use App\Http\Requests\Traits\SingleValidationMessage;
+use Domain\Constant\Tag\Name;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * StoreRequest class
+ */
+final class StoreRequest extends FormRequest
+{
+    use SingleValidationMessage;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:' . Name::MAX_LENGTH,
+            ],
+        ];
+    }
+}

--- a/api/src/app/Providers/RepositoryServiceProvider.php
+++ b/api/src/app/Providers/RepositoryServiceProvider.php
@@ -3,8 +3,10 @@
 namespace App\Providers;
 
 use App\Adapter\Gateway\QuestionnaireRepository;
+use App\Adapter\Gateway\TagRepository;
 use App\Adapter\Gateway\UserRepository;
 use Domain\Repository\QuestionnaireRepositoryInterface;
+use Domain\Repository\TagRepositoryInterface;
 use Domain\Repository\UserRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
 
@@ -22,6 +24,7 @@ class RepositoryServiceProvider extends ServiceProvider
     {
         $this->app->bind(UserRepositoryInterface::class, UserRepository::class);
         $this->app->bind(QuestionnaireRepositoryInterface::class, QuestionnaireRepository::class);
+        $this->app->bind(TagRepositoryInterface::class, TagRepository::class);
     }
 
     /**

--- a/api/src/database/migrations/2022_12_15_155155_create_tags_table.php
+++ b/api/src/database/migrations/2022_12_15_155155_create_tags_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
         Schema::create('tags', function (Blueprint $table) {
             $table->id()->comment('タグID');
             $table->uuid()->unique('idx_tags_uuid')->comment('タグUUID');
-            $table->string('name')->comment('タグ名');
+            $table->string('name')->index('idx_tags_name')->comment('タグ名');
             $table->dateTime('created_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('作成日時');
             $table->dateTime('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('更新日時');
             $table->dateTime('deleted_at')->nullable()->comment('削除日時');

--- a/api/src/domain/Repository/TagRepositoryInterface.php
+++ b/api/src/domain/Repository/TagRepositoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\Repository;
+
+use App\Models\Tag;
+
+/**
+ * TagRepositoryInterface interface
+ */
+interface TagRepositoryInterface
+{
+    /**
+     * タグ名からタグを取得する
+     *
+     * @param string $name
+     * @return Tag|null
+     */
+    public function findByName(string $name): ?Tag;
+
+    /**
+     * タグを登録する
+     *
+     * @param string $name
+     * @return Tag
+     */
+    public function save(string $name): Tag;
+}

--- a/api/src/domain/UseCase/Tag/StoreTag.php
+++ b/api/src/domain/UseCase/Tag/StoreTag.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Domain\UseCase\Tag;
+
+use App\Adapter\Presenter\Tag\StoreTagPresenter;
+use Domain\Repository\TagRepositoryInterface;
+
+/**
+ * StoreTag class
+ */
+final class StoreTag
+{
+    /**
+     * コンストラクタ
+     *
+     * @param TagRepositoryInterface tagRepository
+     */
+    public function __construct(private TagRepositoryInterface $tagRepository)
+    {
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function __invoke(string $name): array
+    {
+        $tag = $this->tagRepository->findByName($name);
+
+        if (is_null($tag)) {
+            $tag = $this->tagRepository->save($name);
+        }
+
+        return (new StoreTagPresenter($tag))->toArray();
+    }
+}

--- a/api/src/routes/api.php
+++ b/api/src/routes/api.php
@@ -21,6 +21,9 @@ Route::as('api.')->group(function () {
             Route::post('/ranking', 'GetRanking')->name('ranking');
             Route::get('/{questionnaireId}', 'Show')->name('show');
         });
+        Route::prefix('tags')->namespace('Tag')->as('tag.')->group(function () {
+            Route::post('/', 'Store')->name('store');
+        });
     });
 
     /**

--- a/api/src/tests/Unit/UseCase/Tag/StoreTagTest.php
+++ b/api/src/tests/Unit/UseCase/Tag/StoreTagTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\UseCase\Tag;
+
+use App\Models\Tag;
+use Domain\UseCase\Tag\StoreTag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+/**
+ * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+ */
+class StoreTagTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * アンケートのタグテストデータ
+     * @var array
+     */
+    private const TAGS = [
+        [
+            'id' => 1,
+            'name' => 'アニメ',
+        ],
+        [
+            'id' => 2,
+            'name' => 'ゲーム',
+        ],
+        [
+            'id' => 3,
+            'name' => 'Youtube',
+        ],
+        [
+            'id' => 4,
+            'name' => 'ポケモン',
+        ],
+    ];
+
+    /**
+     * @throws BindingResolutionException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCase = app()->make(StoreTag::class);
+
+        Tag::factory()->createMany(self::TAGS);
+    }
+
+    /**
+     * @test
+     * @dataProvider 指定されたタグ名DBに存在しない場合タグを新規登録できること_provider
+     *
+     * @return void
+     */
+    public function 指定されたタグ名DBに存在しない場合タグを新規登録できること($input, $expected): void
+    {
+        ($this->useCase)(...$input);
+
+        $actual = Tag::latest()->first()->toArray();
+
+        $this->assertSame(
+            $expected,
+            Arr::only($actual, array_keys($expected))
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function 指定されたタグ名DBに存在しない場合タグを新規登録できること_provider(): array
+    {
+        return [
+            '正常系' => [
+                '入力値' => [
+                    'name' => "ファッション",
+                ],
+                '期待値' => [
+                    'name' => 'ファッション',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider タグの新規登録後に保存したタグ情報が取得できること_provider
+     *
+     * @return void
+     */
+    public function タグの新規登録後に保存したタグ情報が取得できること($input, $expected): void
+    {
+        $actual = ($this->useCase)(...$input);
+
+        $this->assertSame(
+            $expected,
+            Arr::only($actual, array_keys($expected))
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function タグの新規登録後に保存したタグ情報が取得できること_provider(): array
+    {
+        return [
+            '正常系' => [
+                '入力値' => [
+                    'name' => "ファッション",
+                ],
+                '期待値' => [
+                    'name' => 'ファッション',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider 指定されたタグ名がDBに存在する場合そのタグ情報を取得できること_provider
+     *
+     * @return void
+     */
+    public function 指定されたタグ名がDBに存在する場合そのタグ情報を取得できること($input, $expected): void
+    {
+        $actual = ($this->useCase)(...$input);
+
+        $this->assertSame(
+            $expected,
+            Arr::only($actual, array_keys($expected))
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function 指定されたタグ名がDBに存在する場合そのタグ情報を取得できること_provider(): array
+    {
+        return [
+            'タグ名に「アニメ」を指定' => [
+                '入力値' => [
+                    'name' => "アニメ",
+                ],
+                '期待値' => [
+                    'id' => 1,
+                    'name' => 'アニメ',
+                ],
+            ],
+            'タグ名に「ポケモン」を指定' => [
+                '入力値' => [
+                    'name' => "ポケモン",
+                ],
+                '期待値' => [
+                    'id' => 4,
+                    'name' => 'ポケモン',
+                ],
+            ],
+        ];
+    }
+}

--- a/document/api/openapi.yaml
+++ b/document/api/openapi.yaml
@@ -67,7 +67,7 @@ paths:
                 required:
                   - questionnaires
               examples:
-                example:
+                Example:
                   value:
                     questionnaires:
                       - id: 123
@@ -268,7 +268,7 @@ paths:
                   - questionnaire
                   - qreChoices
               examples:
-                example:
+                Example:
                   value:
                     questionnaire:
                       id: 222
@@ -292,6 +292,26 @@ paths:
                         name: アニメ
                       - id: 34
                         name: Youtube
+                タグが付与されていない場合:
+                  value:
+                    questionnaire:
+                      id: 222
+                      title: アンケートタイトルA
+                      description: アンケート説明文A
+                      thumbnailUrl: 'https://images1.png'
+                      createdAt: '2022-10-01 00:00:00'
+                      voteCountAll: 150
+                      user:
+                        id: 33
+                        name: テストユーザー
+                    qreChoices:
+                      - id: 123
+                        body: 選択肢内容A
+                        voteCount: 100
+                      - id: 456
+                        body: 選択肢内容B
+                        voteCount: 50
+                    tags: []
         '400':
           description: バリデーション失敗
           content:
@@ -322,7 +342,7 @@ paths:
                 required:
                   - message
               examples:
-                example:
+                Example:
                   value:
                     message: アンケートが存在しません。
       description: アンケートプレイ画面の詳細を返却
@@ -343,6 +363,19 @@ paths:
       responses:
         '201':
           description: 登録成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+              examples:
+                Example:
+                  value:
+                    message: 登録が完了しました。
         '400':
           description: バリデーションエラー
           content:
@@ -460,6 +493,18 @@ paths:
                       name: アニメ
                     - id: 34
                       name: Youtube
+              タグが付与されていない場合:
+                value:
+                  userId: 12
+                  title: アンケートタイトルA
+                  description: アンケート説明文A
+                  thumbnailUrl: ''
+                  qreChoices:
+                    - body: 選択肢内容A
+                      displayOrder: 1
+                    - body: 選択肢内容B
+                      displayOrder: 2
+                  tags: []
         description: アンケート情報
       tags:
         - アンケート
@@ -478,6 +523,8 @@ paths:
                 properties:
                   message:
                     type: string
+                required:
+                  - message
               examples:
                 Example:
                   value:
@@ -584,6 +631,9 @@ paths:
                     type: integer
                   name:
                     type: string
+                required:
+                  - id
+                  - name
               examples:
                 Example:
                   value:
@@ -606,7 +656,7 @@ paths:
                 required:
                   - message
               examples:
-                Example 1:
+                Example:
                   value:
                     message:
                       name: タグ名は必ず指定してください。
@@ -643,6 +693,8 @@ components:
             properties:
               message:
                 type: string
+            required:
+              - message
           examples:
             Example:
               value:


### PR DESCRIPTION
## タスクのリンク
https://www.notion.so/Table-d4e453638ca3402d80ea87385df80141

## やったこと
- タグ登録APIの実装
  - まだDBに保存されていなければタグを新規登録して登録されたタグ情報を返却
  - DBにすでに存在していればDBからタグ情報を取得して返却

## やらないこと
- なし

## 動作確認
- Postmanでの実行テスト

https://user-images.githubusercontent.com/50767102/209701980-638403da-1a98-4ca4-bb42-53e4ac1f3ea5.mov

## 特にレビューをお願いしたい箇所
なし

## その他
なし