### PR TITLE
SF-030 アンケート登録フロント機能実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ init:
 	docker-compose exec api cp .env.example .env
 	docker-compose exec api composer install
 	docker-compose exec api php artisan key:generate
+	docker-compose run --rm client npm i
 	@make migrate
 	@make seed
-	docker-compose run --rm client npm i
 	@make up
 
 remake:
@@ -66,9 +66,9 @@ remake:
 	docker-compose exec api cp .env.example .env
 	docker-compose exec api composer install
 	docker-compose exec api php artisan key:generate
+	docker-compose run --rm client npm i
 	@make migrate
 	@make seed
-	docker-compose run --rm client npm i
 	@make up
 
 create-network:
@@ -105,7 +105,7 @@ phpmd:
 	docker-compose exec api ./vendor/bin/phpmd ./app,./database/factories,./database/migrations,./routes/api.php,./tests ansi ./phpmd.xml
 tele:
 	@echo "\033[1;33m---------- telescope関連テーブルのレコードを削除 ----------\033[0m"
-	docker-compose exec api php artisan telescope:prune --hours=0
+	-@docker-compose exec api php artisan telescope:prune --hours=0
 
 db:
 	docker-compose exec db bash

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ help:
 	@echo 'migrate                -- DBのマイグレートを実行します'
 	@echo 'migrate-status         -- DBのマイグレート状態を確認します'
 	@echo 'fresh                  -- DBのテーブルを作り直します'
+	@echo 'fresh-seed             -- DBのテーブルとシーディングを作り直します'
 	@echo 'seed                   -- テーブルにデータをシーディングします'
 	@echo 'rollback               -- DBのマイグレートの状態を一つ戻します'
 	@echo ''
@@ -38,6 +39,9 @@ help:
 	@echo 'gs                     -- Gitステータスを確認'
 	@echo 'gl                     -- Gitコミットログを確認'
 	@echo 'gl-ol                  -- Gitコミットログをワンラインで確認'
+	@echo '---------- 便利ツールに関するコマンド ----------'
+	@echo 'open                   -- ブラウザで開発環境のページをブラウザで開く'
+	@echo 'open-prod              -- ブラウザで本番環境のページをブラウザで開く'
 
 init:
 	@echo "\033[1;32mDocker環境のセットアップ中...\033[0m"
@@ -114,6 +118,8 @@ migrate-status:
 	docker-compose exec api php artisan migrate:status
 fresh:
 	docker-compose exec api php artisan migrate:fresh
+fresh-seed:
+	docker-compose exec api php artisan migrate:fresh --seed
 seed:
 	docker-compose exec api php artisan db:seed
 rollback:
@@ -130,3 +136,8 @@ gl:
 	git log
 gl-ol:
 	git log --oneline
+
+open:
+	open http://localhost:3333
+open-prod:
+	open http://localhost:4444

--- a/api/src/.env.example
+++ b/api/src/.env.example
@@ -14,6 +14,7 @@ DB_PORT=3306
 DB_DATABASE=surveyfactory
 DB_USERNAME=user
 DB_PASSWORD=password
+DB_COLLATION=utf8mb4_ja_0900_as_cs_ks
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file

--- a/api/src/app/Http/Requests/Questionnaire/StoreRequest.php
+++ b/api/src/app/Http/Requests/Questionnaire/StoreRequest.php
@@ -50,7 +50,7 @@ final class StoreRequest extends FormRequest
                 'max:' . Title::MAX_LENGTH,
             ],
             'description' => [
-                'required',
+                'nullable',
                 'string',
                 'max:' . Description::MAX_LENGTH,
             ],

--- a/api/src/config/database.php
+++ b/api/src/config/database.php
@@ -53,7 +53,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'collation' => env('DB_COLLATION', 'utf8mb4_ja_0900_as_cs_ks'),
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,

--- a/api/src/database/migrations/2022_12_13_185954_create_questionnaires_table.php
+++ b/api/src/database/migrations/2022_12_13_185954_create_questionnaires_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->id()->comment('アンケートID');
             $table->uuid()->unique('idx_questionnaires_uuid')->comment('アンケートUUID');
             $table->foreignId('user_id')->constrained()->index('idx_questionnaires_user_id')->comment('ユーザーID');
-            $table->string('title', 50)->comment('アンケートタイトル');
+            $table->string('title', 30)->comment('アンケートタイトル');
             $table->string('description', 50)->nullable()->comment('アンケート説明');
             $table->string('thumbnail_url', 2083)->nullable()->comment('サムネイルURL');
             $table->dateTime('created_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('作成日時');

--- a/api/src/database/migrations/2022_12_13_190256_create_qre_choices_table.php
+++ b/api/src/database/migrations/2022_12_13_190256_create_qre_choices_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
                   ->constrained()
                   ->index('idx_qre_choices_questionnaire_id')
                   ->comment('アンケートID');
-            $table->string('body')->comment('選択肢内容');
+            $table->string('body', 30)->comment('選択肢内容');
             $table->unsignedTinyInteger('display_order')->comment('選択肢順序');
             $table->dateTime('created_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('作成日時');
             $table->dateTime('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('更新日時');

--- a/api/src/database/migrations/2022_12_15_155155_create_tags_table.php
+++ b/api/src/database/migrations/2022_12_15_155155_create_tags_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
         Schema::create('tags', function (Blueprint $table) {
             $table->id()->comment('タグID');
             $table->uuid()->unique('idx_tags_uuid')->comment('タグUUID');
-            $table->string('name')->index('idx_tags_name')->comment('タグ名');
+            $table->string('name', 20)->index('idx_tags_name')->comment('タグ名');
             $table->dateTime('created_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('作成日時');
             $table->dateTime('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('更新日時');
             $table->dateTime('deleted_at')->nullable()->comment('削除日時');

--- a/api/src/domain/Constant/QreChoice/Body.php
+++ b/api/src/domain/Constant/QreChoice/Body.php
@@ -14,5 +14,5 @@ final class Body
      *
      * @var int
      */
-    public const MAX_LENGTH = 255;
+    public const MAX_LENGTH = 30;
 }

--- a/api/src/domain/Constant/Tag/Name.php
+++ b/api/src/domain/Constant/Tag/Name.php
@@ -14,5 +14,5 @@ final class Name
      *
      * @var int
      */
-    public const MAX_LENGTH = 255;
+    public const MAX_LENGTH = 20;
 }

--- a/client/src/components/formParts/InputChoice.tsx
+++ b/client/src/components/formParts/InputChoice.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import styles from '../../styles/components/formParts/Form.module.scss';
+import { removeError } from '../../utils/validation';
+
+interface InputChoiceProps {
+  index: number;
+  displayOrder: number;
+  maxLength: number;
+  validationName: string;
+}
+
+export const InputChoice: React.FC<InputChoiceProps> = ({
+  index,
+  displayOrder,
+  maxLength,
+  validationName,
+}) => {
+  // 選択肢のテキストフィールドと文字数のstate
+  const [inputChoice, setInputChoice] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const target = e.target;
+    const newInput = target.value;
+
+    // 文字入力後エラーを外す
+    removeError(target);
+
+    // 最大文字数に達していない場合のみ入力を反映
+    if (newInput.length <= maxLength) {
+      setInputChoice(target.value);
+    }
+  };
+
+  return (
+    <>
+      <label htmlFor={`choice_${displayOrder}`} className={styles.text_label}></label>
+      <input
+        type="text"
+        id={`choice_${displayOrder}`}
+        className={`${styles.form_parts} ${styles.input_text} validate-text`}
+        name={`choice_${displayOrder}`}
+        placeholder={`${displayOrder}つ目の選択肢`}
+        maxLength={maxLength}
+        value={inputChoice}
+        data-validation-name={validationName}
+        onChange={handleChange}
+      />
+    </>
+  );
+};

--- a/client/src/components/formParts/InputChoice.tsx
+++ b/client/src/components/formParts/InputChoice.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { errorMessageState } from '../../states/atoms/errorMessageAtom';
 import styles from '../../styles/components/formParts/Form.module.scss';
 import { removeError } from '../../utils/validation';
 
@@ -18,12 +20,18 @@ export const InputChoice: React.FC<InputChoiceProps> = ({
   // 選択肢のテキストフィールドと文字数のstate
   const [inputChoice, setInputChoice] = useState('');
 
+  // エラーメッセージのstate
+  const [errorMessage, setErrorMessage] = useRecoilState(errorMessageState);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     const newInput = target.value;
 
-    // 文字入力後エラーを外す
+    // 文字入力後エラーメッセージを外す
     removeError(target);
+    const removeErrorMessage = {...errorMessage};
+    delete removeErrorMessage[`choice_${displayOrder}`];
+    setErrorMessage(removeErrorMessage);
 
     // 最大文字数に達していない場合のみ入力を反映
     if (newInput.length <= maxLength) {
@@ -45,6 +53,11 @@ export const InputChoice: React.FC<InputChoiceProps> = ({
         data-validation-name={validationName}
         onChange={handleChange}
       />
+      {errorMessage[`choice_${displayOrder}`] ? (
+        <div className={styles.error_area}>
+          <span className={styles.error_text}>{errorMessage[`choice_${displayOrder}`]}</span>
+        </div>
+      ) : null}
     </>
   );
 };

--- a/client/src/components/formParts/InputChoice.tsx
+++ b/client/src/components/formParts/InputChoice.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useEffect, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { addChoiceListState } from '../../states/atoms/addChoiceListAtom';
 import { errorMessageState } from '../../states/atoms/errorMessageAtom';
 import styles from '../../styles/components/formParts/Form.module.scss';
 import { removeError } from '../../utils/validation';
@@ -20,8 +21,18 @@ export const InputChoice: React.FC<InputChoiceProps> = ({
   // 選択肢のテキストフィールドと文字数のstate
   const [inputChoice, setInputChoice] = useState('');
 
+  // 選択肢配列のstateのセッター関数
+  const addChoiceList = useRecoilValue(addChoiceListState);
+
   // エラーメッセージのstate
   const [errorMessage, setErrorMessage] = useRecoilState(errorMessageState);
+
+  // submit後にテキストフィールドを空にする
+  useEffect(() => {
+    if (addChoiceList[index]['body'] === '') {
+      setInputChoice('');
+    }
+  }, [addChoiceList]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
@@ -29,7 +40,7 @@ export const InputChoice: React.FC<InputChoiceProps> = ({
 
     // 文字入力後エラーメッセージを外す
     removeError(target);
-    const removeErrorMessage = {...errorMessage};
+    const removeErrorMessage = { ...errorMessage };
     delete removeErrorMessage[`choice_${displayOrder}`];
     setErrorMessage(removeErrorMessage);
 

--- a/client/src/components/formParts/InputChoiceArea.tsx
+++ b/client/src/components/formParts/InputChoiceArea.tsx
@@ -1,0 +1,32 @@
+import { useRecoilValue } from 'recoil';
+import { addChoiceListState } from '../../states/atoms/addChoiceListAtom';
+import styles from '../../styles/components/formParts/Form.module.scss';
+import { InputChoice } from './InputChoice';
+
+interface InputChoiceAreaProps {
+  title: string;
+}
+
+export const InputChoiceArea: React.FC<InputChoiceAreaProps> = ({ title }) => {
+  // 選択肢リストのstate
+  const addChoiceList = useRecoilValue(addChoiceListState);
+
+  return (
+    <div className={styles.input_row}>
+      <div className={styles.choice_create}>
+        <label htmlFor="#" className={styles.text_label}>
+          {title}
+        </label>
+        {addChoiceList.map((inputChoice, key) => (
+          <InputChoice
+            index={key}
+            displayOrder={inputChoice.displayOrder}
+            maxLength={30}
+            validationName="選択肢"
+            key={key}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/formParts/InputImage.tsx
+++ b/client/src/components/formParts/InputImage.tsx
@@ -1,0 +1,26 @@
+import { faFileImage } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styles from '../../styles/components/formParts/Form.module.scss';
+
+interface InputImageProps {
+  title: string;
+  id: string;
+  name: string;
+}
+
+export const InputImage: React.FC<InputImageProps> = ({ title, id, name }) => {
+  return (
+    <div className={styles.input_row}>
+      <label htmlFor={id} className={styles.image_label}>
+        <FontAwesomeIcon icon={faFileImage} />
+        {title}
+      </label>
+      <input
+        type="file"
+        id={id}
+        className={`${styles.form_parts} ${styles.input_image}`}
+        name={name}
+      />
+    </div>
+  );
+};

--- a/client/src/components/formParts/InputTag.tsx
+++ b/client/src/components/formParts/InputTag.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Tag } from '../../domain/models/tag';
 import { addTagListState } from '../../states/atoms/addTagListAtom';
@@ -26,6 +27,13 @@ export const InputTag: React.FC<InputTagProps> = ({ title, id, name, placeholder
   // 追加されたタグリストとそのリストに含まれるタグの個数
   const [addTagList, setAddTagList] = useRecoilState(addTagListState);
   const addTagListLength = useRecoilValue(addTagListLengthState);
+
+  // 初期化
+  useEffect(() => {
+    if (addTagList.length === 0) {
+      setInputTag('');
+    }
+  }, [addTagList]);
 
   // テキスト入力時のイベント
   const handleInputChange = (e: any) => {

--- a/client/src/components/formParts/InputTag.tsx
+++ b/client/src/components/formParts/InputTag.tsx
@@ -87,20 +87,20 @@ export const InputTag: React.FC<InputTagProps> = ({ title, id, name, placeholder
           disabled={addTagListLength >= 3}
           onChange={handleInputChange}
         />
-        <div className={styles.tags}>
-          {addTagList.map((tag, key) => (
-            <span className={styles.tag} id={`tag_${tag.id}`} key={key}>
-              <span># {tag.name}</span>
-              <a
-                href="#"
-                className={styles.tag_remove}
-                title={`${tag.name}タグを削除`}
-                onClick={() => removeTag(tag.id)}
-              ></a>
-            </span>
-          ))}
-        </div>
       </form>
+      <div className={styles.tags}>
+        {addTagList.map((tag, key) => (
+          <span className={styles.tag} id={`tag_${tag.id}`} key={key}>
+            <span># {tag.name}</span>
+            <a
+              href="#"
+              className={styles.tag_remove}
+              title={`${tag.name}タグを削除`}
+              onClick={() => removeTag(tag.id)}
+            ></a>
+          </span>
+        ))}
+      </div>
     </div>
   );
 };

--- a/client/src/components/formParts/InputTag.tsx
+++ b/client/src/components/formParts/InputTag.tsx
@@ -1,0 +1,99 @@
+import { GetServerSideProps, NextPage } from 'next';
+import React, { useState } from 'react';
+import styles from '../../styles/components/formParts/Form.module.scss';
+import { TagUseCase } from '../../usecase/tagUseCase';
+
+interface InputTagProps {
+  title: string;
+  id: string;
+  name: string;
+  placeholder: string;
+  maxLength: number;
+}
+
+type TagList = {
+  id: number;
+  name: string;
+};
+
+const tagUseCase = new TagUseCase();
+
+export const InputTag: React.FC<InputTagProps> = ({ title, id, name, placeholder, maxLength }) => {
+  // タグ名のテキストフィールド
+  const [tagInput, setTagInput] = useState('');
+  // タグ名のテキストフィールドの文字数
+  const [tagInputCount, setTagInputCount] = useState(0);
+  // 追加されたタグのリスト
+  const [tagList, setTagList] = useState<TagList[]>([]);
+
+  // テキスト入力時のイベント
+  const handleTagInputChange = (e: any) => {
+    // 最大文字数の場合入力を拒否
+    if (e.target.value.length > maxLength) {
+      return;
+    }
+
+    setTagInput(e.target.value);
+    setTagInputCount(e.target.value.length);
+  };
+
+  // エンターキー押下時タグを登録
+  const handleTagSubmit = async (e: any) => {
+    e.preventDefault();
+
+    // リストが既に3つ以上の場合は登録しない
+    if (tagList.length >= 3) {
+      return;
+    }
+
+    const { data } = await tagUseCase.postTag(tagInput);
+    const newTagList: TagList[] = [...tagList, data];
+
+    setTagInput('');
+
+    setTagList(newTagList);
+  };
+
+  const removeTag = (id: number) => {
+    setTagList((tagList) => {
+      return tagList.filter(tag => tag.id !== id);
+    });
+  };
+
+  const testButton = () => {
+    console.log(tagList);
+  };
+
+  return (
+    <div className={styles.input_row}>
+      <form onSubmit={handleTagSubmit}>
+        <label htmlFor={id} className={styles.text_label}>
+          {title}
+          <span className={styles.text_count}>
+            {tagInputCount}/{maxLength}
+          </span>
+        </label>
+        <input
+          type="text"
+          id={id}
+          className={`${styles.form_parts} ${styles.input} ${styles['-short']}`}
+          name={name}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          value={tagInput}
+          disabled={tagList.length >= 3}
+          onChange={handleTagInputChange}
+        />
+        <div className={styles.tags}>
+          {tagList.map((tag, key) => (
+            <span className={styles.tag} id={`tag_${tag.id}`} key={key}>
+              <span># {tag.name}</span>
+              <a href="#" className={styles.tag_remove} title={`${tag.name}タグを削除`} onClick={() => removeTag(tag.id)}></a>
+            </span>
+          ))}
+        </div>
+      </form>
+      <button onClick={testButton}>確認ボタン</button>
+    </div>
+  );
+};

--- a/client/src/components/formParts/InputText.tsx
+++ b/client/src/components/formParts/InputText.tsx
@@ -1,0 +1,48 @@
+import { GetServerSideProps, NextPage } from 'next';
+import React, { useState } from 'react';
+import styles from '../../styles/components/formParts/Form.module.scss';
+
+interface InputTextProps {
+  title: string;
+  id: string;
+  name: string;
+  placeholder: string;
+  maxLength: number;
+}
+
+export const InputText: React.FC<InputTextProps> = ({ title, id, name, placeholder, maxLength }) => {
+
+  // タグ名のテキストフィールド
+  const [textInput, setTextInput] = useState('');
+  // タグ名のテキストフィールドの文字数
+  const [textInputCount, setTextInputCount] = useState(0);
+
+  const handleTagInputChange = (e: any) => {
+    // 最大文字数の場合入力を拒否
+    if (e.target.value.length > maxLength) {
+      return false;
+    }
+
+    setTextInput(e.target.value);
+    setTextInputCount(e.target.value.length);
+  };
+
+  return (
+    <div className={styles.input_row}>
+      <label htmlFor={id} className={styles.text_label}>
+        {title}
+        <span className={styles.text_count}>{textInputCount}/{maxLength}</span>
+      </label>
+      <input
+        type="text"
+        id={id}
+        className={`${styles.form_parts} ${styles.input}`}
+        name={name}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        value={textInput}
+        onChange={handleTagInputChange}
+      />
+    </div>
+  );
+};

--- a/client/src/components/formParts/InputText.tsx
+++ b/client/src/components/formParts/InputText.tsx
@@ -1,4 +1,4 @@
-import { SetterOrUpdater, useRecoilState, useRecoilValue } from 'recoil';
+import { SetterOrUpdater, useRecoilState } from 'recoil';
 import { errorMessageState } from '../../states/atoms/errorMessageAtom';
 import styles from '../../styles/components/formParts/Form.module.scss';
 import { removeError } from '../../utils/validation';
@@ -34,7 +34,7 @@ export const InputText: React.FC<InputTextProps> = ({
 
     // 文字入力後エラーメッセージを外す
     removeError(target);
-    const removeErrorMessage = {...errorMessage};
+    const removeErrorMessage = { ...errorMessage };
     delete removeErrorMessage[name];
     setErrorMessage(removeErrorMessage);
 

--- a/client/src/components/formParts/InputText.tsx
+++ b/client/src/components/formParts/InputText.tsx
@@ -1,6 +1,5 @@
-import React, { useContext } from 'react';
-import { SetterOrUpdater } from 'recoil';
-import { ErrorMessage } from '../../pages/questionnaires/create';
+import { SetterOrUpdater, useRecoilState, useRecoilValue } from 'recoil';
+import { errorMessageState } from '../../states/atoms/errorMessageAtom';
 import styles from '../../styles/components/formParts/Form.module.scss';
 import { removeError } from '../../utils/validation';
 
@@ -13,7 +12,7 @@ interface InputTextProps {
   validationName: string;
   inputText: string;
   setInputText: SetterOrUpdater<string>;
-  inputTextLength: number
+  inputTextLength: number;
 }
 
 export const InputText: React.FC<InputTextProps> = ({
@@ -25,15 +24,19 @@ export const InputText: React.FC<InputTextProps> = ({
   validationName,
   inputText,
   setInputText,
-  inputTextLength
+  inputTextLength,
 }) => {
-  // エラーメッセージ
-  const error = useContext(ErrorMessage);
+  // エラーメッセージのstate
+  const [errorMessage, setErrorMessage] = useRecoilState(errorMessageState);
 
   const handleChange = (e: any) => {
     const target = e.target;
-    // 文字入力後エラーを外す
+
+    // 文字入力後エラーメッセージを外す
     removeError(target);
+    const removeErrorMessage = {...errorMessage};
+    delete removeErrorMessage[name];
+    setErrorMessage(removeErrorMessage);
 
     // 最大文字数に達していない場合のみ入力を反映
     if (target.value.length <= maxLength) {
@@ -60,9 +63,9 @@ export const InputText: React.FC<InputTextProps> = ({
         value={inputText}
         onChange={handleChange}
       />
-      {error['title'] ? (
+      {errorMessage[name] ? (
         <div className={styles.error_area}>
-          <span className={styles.error_text}>{error['title']}</span>
+          <span className={styles.error_text}>{errorMessage[name]}</span>
         </div>
       ) : null}
     </div>

--- a/client/src/components/formParts/InputText.tsx
+++ b/client/src/components/formParts/InputText.tsx
@@ -1,6 +1,8 @@
-import { GetServerSideProps, NextPage } from 'next';
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
+import { SetterOrUpdater } from 'recoil';
+import { ErrorMessage } from '../../pages/questionnaires/create';
 import styles from '../../styles/components/formParts/Form.module.scss';
+import { removeError } from '../../utils/validation';
 
 interface InputTextProps {
   title: string;
@@ -8,41 +10,61 @@ interface InputTextProps {
   name: string;
   placeholder: string;
   maxLength: number;
+  validationName: string;
+  inputText: string;
+  setInputText: SetterOrUpdater<string>;
+  inputTextLength: number
 }
 
-export const InputText: React.FC<InputTextProps> = ({ title, id, name, placeholder, maxLength }) => {
+export const InputText: React.FC<InputTextProps> = ({
+  title,
+  id,
+  name,
+  placeholder,
+  maxLength,
+  validationName,
+  inputText,
+  setInputText,
+  inputTextLength
+}) => {
+  // エラーメッセージ
+  const error = useContext(ErrorMessage);
 
-  // タグ名のテキストフィールド
-  const [textInput, setTextInput] = useState('');
-  // タグ名のテキストフィールドの文字数
-  const [textInputCount, setTextInputCount] = useState(0);
+  const handleChange = (e: any) => {
+    const target = e.target;
+    // 文字入力後エラーを外す
+    removeError(target);
 
-  const handleTagInputChange = (e: any) => {
-    // 最大文字数の場合入力を拒否
-    if (e.target.value.length > maxLength) {
-      return false;
+    // 最大文字数に達していない場合のみ入力を反映
+    if (target.value.length <= maxLength) {
+      setInputText(target.value);
     }
-
-    setTextInput(e.target.value);
-    setTextInputCount(e.target.value.length);
   };
 
   return (
     <div className={styles.input_row}>
       <label htmlFor={id} className={styles.text_label}>
         {title}
-        <span className={styles.text_count}>{textInputCount}/{maxLength}</span>
+        <span className={styles.text_count}>
+          {inputTextLength}/{maxLength}
+        </span>
       </label>
       <input
         type="text"
         id={id}
-        className={`${styles.form_parts} ${styles.input}`}
+        className={`${styles.form_parts} ${styles.input_text} validate-text`}
         name={name}
         placeholder={placeholder}
         maxLength={maxLength}
-        value={textInput}
-        onChange={handleTagInputChange}
+        data-validation-name={validationName}
+        value={inputText}
+        onChange={handleChange}
       />
+      {error['title'] ? (
+        <div className={styles.error_area}>
+          <span className={styles.error_text}>{error['title']}</span>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/client/src/components/layouts/Header.tsx
+++ b/client/src/components/layouts/Header.tsx
@@ -7,7 +7,7 @@ export const Header = () => {
       <div className={styles.header_inner}>
         <nav>
           <Link href="/" className={styles.header_nav_button}>アンケートを探す</Link>
-          <Link href="/" className={styles.header_nav_button}>アンケートを作る</Link>
+          <Link href="/questionnaires/create" className={styles.header_nav_button}>アンケートを作る</Link>
           <Link href="/" className={styles.header_nav_button}>ランキング</Link>
         </nav>
         <div className={styles.header_button_wrapper}>

--- a/client/src/domain/models/qreChoice.ts
+++ b/client/src/domain/models/qreChoice.ts
@@ -1,5 +1,6 @@
 export interface QreChoice {
   id: number;
   body: string;
+  displayOrder: number;
   voteCount: number;
 };

--- a/client/src/domain/useCaseProps/questionnaire/storeQuestionnaireProps.ts
+++ b/client/src/domain/useCaseProps/questionnaire/storeQuestionnaireProps.ts
@@ -1,0 +1,11 @@
+import { QreChoice } from "../../models/qreChoice";
+import { Tag } from "../../models/tag";
+
+export interface StoreQuestionnaireProps {
+  userId: number;
+  title: string;
+  description: string;
+  thumbnailUrl: string;
+  qreChoices: Omit<QreChoice, 'id' | 'voteCount'>[];
+  tags: Tag[];
+}

--- a/client/src/package-lock.json
+++ b/client/src/package-lock.json
@@ -8,9 +8,14 @@
       "name": "src",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.3.0",
+        "@fortawesome/free-regular-svg-icons": "^6.3.0",
+        "@fortawesome/free-solid-svg-icons": "^6.3.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@types/node": "18.11.12",
         "@types/react": "18.0.26",
         "@types/react-dom": "18.0.9",
+        "@types/recoil": "^0.0.9",
         "axios": "^1.2.1",
         "cookies-next": "^2.1.1",
         "eslint": "8.29.0",
@@ -18,6 +23,7 @@
         "next": "13.0.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "recoil": "^0.7.6",
         "typescript": "4.9.4"
       },
       "devDependencies": {
@@ -67,6 +73,63 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
+      "integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
+      "integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.3.0.tgz",
+      "integrity": "sha512-cZnwiVHZ51SVzWHOaNCIA+u9wevZjCuAGSvSYpNlm6A4H4Vhwh8481Bf/5rwheIC3fFKlgXxLKaw8Xeroz8Ntg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.3.0.tgz",
+      "integrity": "sha512-x5tMwzF2lTH8pyv8yeZRodItP2IVlzzmBuD1M7BjawWgg9XAvktqJJ91Qjgoaf8qJpHQ8FEU9VxRfOkLhh86QA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -407,6 +470,15 @@
       "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/recoil": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/recoil/-/recoil-0.0.9.tgz",
+      "integrity": "sha512-dXKcvdzQbkFCcULgxhtc/3shoCNqsspRUY1KwIUYcAzgS0qY7+IxlcjRjq+9PizFnzKrHESllkbezqCMstPmQA==",
+      "deprecated": "This is a stub types definition. recoil provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "recoil": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -1826,6 +1898,11 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2788,6 +2865,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -3339,6 +3435,43 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
+      "integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
+      "integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.3.0.tgz",
+      "integrity": "sha512-cZnwiVHZ51SVzWHOaNCIA+u9wevZjCuAGSvSYpNlm6A4H4Vhwh8481Bf/5rwheIC3fFKlgXxLKaw8Xeroz8Ntg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.3.0.tgz",
+      "integrity": "sha512-x5tMwzF2lTH8pyv8yeZRodItP2IVlzzmBuD1M7BjawWgg9XAvktqJJ91Qjgoaf8qJpHQ8FEU9VxRfOkLhh86QA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
@@ -3535,6 +3668,14 @@
       "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/recoil": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/recoil/-/recoil-0.0.9.tgz",
+      "integrity": "sha512-dXKcvdzQbkFCcULgxhtc/3shoCNqsspRUY1KwIUYcAzgS0qY7+IxlcjRjq+9PizFnzKrHESllkbezqCMstPmQA==",
+      "requires": {
+        "recoil": "*"
       }
     },
     "@types/scheduler": {
@@ -4554,6 +4695,11 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5190,6 +5336,14 @@
       "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "regenerator-runtime": {

--- a/client/src/package.json
+++ b/client/src/package.json
@@ -10,9 +10,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.3.0",
+    "@fortawesome/free-regular-svg-icons": "^6.3.0",
+    "@fortawesome/free-solid-svg-icons": "^6.3.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@types/node": "18.11.12",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
+    "@types/recoil": "^0.0.9",
     "axios": "^1.2.1",
     "cookies-next": "^2.1.1",
     "eslint": "8.29.0",
@@ -20,6 +25,7 @@
     "next": "13.0.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "recoil": "^0.7.6",
     "typescript": "4.9.4"
   },
   "devDependencies": {

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -2,13 +2,16 @@ import '../styles/globals.scss';
 
 import type { AppProps } from 'next/app';
 import Layout from '../components/Layout';
+import { RecoilRoot } from 'recoil';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <div className='wrapper'>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </div>
+    <RecoilRoot>
+      <div className="wrapper">
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </div>
+    </RecoilRoot>
   );
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -47,7 +47,10 @@ export default Home;
 
 export const getServerSideProps: GetServerSideProps = async () => {
   const useCase = new QuestionnaireUseCase();
-  const { data } = await useCase.getRankingList('vote', 1, 10);
+
+  // アンケート作成機能動作確認のため一時的に100個と作成順にアンケートを取得
+  // const { data } = await useCase.getRankingList('vote', 1, 10);
+  const { data } = await useCase.getRankingList('created_at', 1, 100);
 
   return {
     props: {

--- a/client/src/pages/questionnaires/[id].tsx
+++ b/client/src/pages/questionnaires/[id].tsx
@@ -14,7 +14,7 @@ import BeforeResult from '../../components/questionnaires/BeforeResult';
 
 type QuestionnaireDetailPage = {
   questionnaire: Questionnaire;
-  qreChoices: QreChoice[];
+  qreChoices: Omit<QreChoice, 'displayOrder'>[];
   tags: Tag[];
 };
 

--- a/client/src/pages/questionnaires/create.tsx
+++ b/client/src/pages/questionnaires/create.tsx
@@ -17,6 +17,7 @@ import form_styles from '../../styles/components/formParts/Form.module.scss';
 import { QuestionnaireUseCase } from '../../usecase/questionnaireUseCase';
 import { validation } from '../../utils/validation';
 import { errorMessageState } from '../../states/atoms/errorMessageAtom';
+import { addChoiceListState } from '../../states/atoms/addChoiceListAtom';
 
 const questionnaireUseCase = new QuestionnaireUseCase();
 
@@ -32,7 +33,10 @@ const QuestionnaireCreatePage: NextPage = () => {
   const inputDescriptionLength = useRecoilValue(inputDescriptionLengthState);
 
   // 追加されたタグリストとそのリストに含まれるタグの個数
-  const addTagList = useRecoilValue(addTagListState);
+  const [addTagList, setAddTagList] = useRecoilState(addTagListState);
+
+  // 選択肢配列のstateのセッター関数
+  const setAddChoiceList = useSetRecoilState(addChoiceListState);
 
   // エラーメッセージを更新するセッター関数
   const setErrorMessage = useSetRecoilState(errorMessageState);
@@ -56,10 +60,14 @@ const QuestionnaireCreatePage: NextPage = () => {
     const { data } = await questionnaireUseCase.storeQuestionnaire(questionnaire);
     const message = data.message;
 
+    // RecoilのStateをリセットする
+    recoilStateReset();
+
     // TODO: マイページにリダイレクト
     alert(`${message}\nTODO: マイページの自分の作ったアンケート一覧にリダイレクトする予定`);
   };
 
+  // アンケートSubmit後、選択肢のオブジェクトを生成する
   const setChoices = (): Omit<QreChoice, 'id' | 'voteCount'>[] => {
     const choices = [...document.querySelectorAll('input[name^=choice]')] as HTMLInputElement[];
 
@@ -71,6 +79,24 @@ const QuestionnaireCreatePage: NextPage = () => {
     });
 
     return newList;
+  };
+
+  // アンケートSubmiｔ完了後、RecoilのStateをリセットする
+  const recoilStateReset = () => {
+    setInputTitle('');
+    setInputDescription('');
+    setAddTagList([]);
+    setAddChoiceList([
+      {
+        body: '',
+        displayOrder: 1,
+      },
+      {
+        body: '',
+        displayOrder: 2,
+      },
+    ]);
+    setErrorMessage({});
   };
 
   return (

--- a/client/src/pages/questionnaires/create.tsx
+++ b/client/src/pages/questionnaires/create.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from 'next';
-import { createContext } from 'react';
+import { createContext, useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { InputChoiceArea } from '../../components/formParts/InputChoiceArea';
 // import { InputImage } from '../../components/formParts/InputImage';
@@ -40,6 +40,24 @@ const QuestionnaireCreatePage: NextPage = () => {
 
   // エラーメッセージを更新するセッター関数
   const setErrorMessage = useSetRecoilState(errorMessageState);
+
+  // recoilで管理してるフィールドの初期化
+  useEffect(() => {
+    setInputTitle('');
+    setInputDescription('');
+    setAddTagList([]);
+    setAddChoiceList([
+      {
+        body: '',
+        displayOrder: 1,
+      },
+      {
+        body: '',
+        displayOrder: 2,
+      },
+    ]);
+    setErrorMessage({});
+  }, []);
 
   const submitButton = async () => {
     if (Object.keys(validation()).length) {

--- a/client/src/pages/questionnaires/create.tsx
+++ b/client/src/pages/questionnaires/create.tsx
@@ -1,0 +1,65 @@
+import { GetServerSideProps, NextPage } from 'next';
+import Link from 'next/link';
+import { InputTag } from '../../components/formParts/InputTag';
+import { InputText } from '../../components/formParts/InputText';
+import styles from '../../styles/Home.module.scss';
+
+type QuestionnaireCreatePage = {};
+
+const QuestionnaireCreatePage: NextPage<QuestionnaireCreatePage> = () => {
+  return (
+    <>
+      <div className={styles.questionnaire_create}>
+        <div className={styles.content_inner}>
+          <div className={styles.questionnaire_container}>
+            <section className={styles.questionnaire_section}>
+              <h3>アンケートのタイトル</h3>
+              <p className={styles.description}>
+                アンケートのタイトルと簡潔な説明を設定してください
+              </p>
+              <InputText
+                title="タイトル"
+                id="title"
+                name="title"
+                placeholder="例：目玉焼きには醤油派？ソース派"
+                maxLength={30}
+              />
+              <InputText
+                title="アンケートのかんたんな説明"
+                id="description"
+                name="description"
+                placeholder="例：目玉焼きにかける調味料は醤油が好き？それともソースが好き？"
+                maxLength={50}
+              />
+            </section>
+            <section className={styles.questionnaire_section}>
+              <h3>タグを設定</h3>
+              <p className={styles.description}>アンケートに設定するタグを3つまで設定できます</p>
+              <InputTag
+                title="タグ"
+                id="tagName"
+                name="tagName"
+                placeholder="例：アニメ クレヨンしんちゃん 映画"
+                maxLength={20}
+              />
+            </section>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default QuestionnaireCreatePage;
+
+// export const getServerSideProps: GetServerSideProps = async () => {
+//   const useCase = new QuestionnaireUseCase();
+//   const { data } = await useCase.getRankingList('vote', 1, 10);
+
+//   return {
+//     props: {
+//       questionnaires: data.questionnaires,
+//       pager: data.pager,
+//     },
+//   };
+// };

--- a/client/src/pages/questionnaires/create.tsx
+++ b/client/src/pages/questionnaires/create.tsx
@@ -1,12 +1,90 @@
-import { GetServerSideProps, NextPage } from 'next';
-import Link from 'next/link';
+import { NextPage } from 'next';
+import { createContext, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { InputChoiceArea } from '../../components/formParts/InputChoiceArea';
+import { InputImage } from '../../components/formParts/InputImage';
 import { InputTag } from '../../components/formParts/InputTag';
 import { InputText } from '../../components/formParts/InputText';
+import { QreChoice } from '../../domain/models/qreChoice';
+import { StoreQuestionnaireProps } from '../../domain/useCaseProps/questionnaire/storeQuestionnaireProps';
+import { addChoiceListState } from '../../states/atoms/addChoiceListAtom';
+import { addTagListState } from '../../states/atoms/addTagListAtom';
+import { inputDescriptionState } from '../../states/atoms/inputDescriptionAtom';
+import { inputTitleState } from '../../states/atoms/inputTitleAtom';
+import { inputDescriptionLengthState } from '../../states/selectors/inputDescriptionLengthSelector';
+import { inputTitleLengthState } from '../../states/selectors/inputTitleLengthSelector';
 import styles from '../../styles/Home.module.scss';
+import form_styles from '../../styles/components/formParts/Form.module.scss';
+import { QuestionnaireUseCase } from '../../usecase/questionnaireUseCase';
+import { validation } from '../../utils/validation';
 
-type QuestionnaireCreatePage = {};
+const questionnaireUseCase = new QuestionnaireUseCase();
 
-const QuestionnaireCreatePage: NextPage<QuestionnaireCreatePage> = () => {
+export const ErrorMessage = createContext({});
+
+const QuestionnaireCreatePage: NextPage = () => {
+  // タイトルのテキストフィールドと文字数のstate
+  const [inputTitle, setInputTitle] = useRecoilState(inputTitleState);
+  const inputTitleLength = useRecoilValue(inputTitleLengthState);
+
+  // 説明文のテキストフィールドと文字数のstate
+  const [inputDescription, setInputDescription] = useRecoilState(inputDescriptionState);
+  const inputDescriptionLength = useRecoilValue(inputDescriptionLengthState);
+
+  // 追加されたタグリストとそのリストに含まれるタグの個数
+  const addTagList = useRecoilValue(addTagListState);
+
+  // 選択肢リストのstate
+  const [addChoiceList, setAddChoiceList] = useRecoilState(addChoiceListState);
+
+  const [error, setError] = useState({});
+
+  const submitButton = async () => {
+    if (Object.keys(validation()).length) {
+      setError(validation());
+      console.log(validation());
+      return;
+    }
+
+    const questionnaire: StoreQuestionnaireProps = {
+      userId: 11,
+      title: inputTitle,
+      description: inputDescription,
+      thumbnailUrl: '',
+      qreChoices: setChoices(),
+      tags: addTagList,
+    };
+
+    console.log(questionnaire);
+
+    const { data } = await questionnaireUseCase.storeQuestionnaire(questionnaire);
+    const message = data.message;
+    console.log(data);
+
+    alert(`${message}\nTODO: マイページの自分の作ったアンケート一覧にリダイレクトする予定`);
+  };
+
+  const setChoices = (): Omit<QreChoice, 'id' | 'voteCount'>[] => {
+    const choices = [...document.querySelectorAll('input[name^=choice]')] as HTMLInputElement[];
+
+    const newList = choices.map((choice, index) => {
+      return {
+        body: choice.value,
+        displayOrder: index + 1,
+      };
+    });
+
+    return newList;
+  };
+
+  const errorButton = () => {
+    console.log(error.title);
+  };
+
+  const testButton = () => {
+    console.log(addChoiceList);
+  };
+
   return (
     <>
       <div className={styles.questionnaire_create}>
@@ -17,19 +95,29 @@ const QuestionnaireCreatePage: NextPage<QuestionnaireCreatePage> = () => {
               <p className={styles.description}>
                 アンケートのタイトルと簡潔な説明を設定してください
               </p>
-              <InputText
-                title="タイトル"
-                id="title"
-                name="title"
-                placeholder="例：目玉焼きには醤油派？ソース派"
-                maxLength={30}
-              />
+              <ErrorMessage.Provider value={ErrorMessage}>
+                <InputText
+                  title="タイトル"
+                  id="title"
+                  name="title"
+                  placeholder="例：目玉焼きには醤油派？ソース派"
+                  maxLength={30}
+                  validationName="タイトル"
+                  inputText={inputTitle}
+                  setInputText={setInputTitle}
+                  inputTextLength={inputTitleLength}
+                />
+              </ErrorMessage.Provider>
               <InputText
                 title="アンケートのかんたんな説明"
                 id="description"
                 name="description"
                 placeholder="例：目玉焼きにかける調味料は醤油が好き？それともソースが好き？"
                 maxLength={50}
+                validationName="アンケート説明文"
+                inputText={inputDescription}
+                setInputText={setInputDescription}
+                inputTextLength={inputDescriptionLength}
               />
             </section>
             <section className={styles.questionnaire_section}>
@@ -43,6 +131,33 @@ const QuestionnaireCreatePage: NextPage<QuestionnaireCreatePage> = () => {
                 maxLength={20}
               />
             </section>
+            {/* <section className={styles.questionnaire_section}>
+              <h3>サムネイル</h3>
+              <p className={styles.description}>SNSにシェアされたとき表示される画像を設定できます</p>
+              <InputImage
+                title="サムネイル画像をアップロードする"
+                id="thumbnail"
+                name="thumbnail"
+              />
+            </section> */}
+            <section className={styles.questionnaire_section}>
+              <h3>選択肢を追加</h3>
+              <p className={styles.description}>
+                アンケートの設問に対する選択肢を追加してください。
+              </p>
+              <InputChoiceArea title="選択肢を追加" />
+            </section>
+            <section className={styles.questionnaire_section}>
+              <button className={form_styles.submit_button} onClick={() => submitButton()}>
+                アンケートを公開する
+              </button>
+            </section>
+            <button className={form_styles.submit_button} onClick={() => errorButton()}>
+              デバッグエラー
+            </button>
+            <button className={form_styles.submit_button} onClick={() => testButton()}>
+              テストボタン
+            </button>
           </div>
         </div>
       </div>
@@ -51,15 +166,3 @@ const QuestionnaireCreatePage: NextPage<QuestionnaireCreatePage> = () => {
 };
 
 export default QuestionnaireCreatePage;
-
-// export const getServerSideProps: GetServerSideProps = async () => {
-//   const useCase = new QuestionnaireUseCase();
-//   const { data } = await useCase.getRankingList('vote', 1, 10);
-
-//   return {
-//     props: {
-//       questionnaires: data.questionnaires,
-//       pager: data.pager,
-//     },
-//   };
-// };

--- a/client/src/pages/questionnaires/create.tsx
+++ b/client/src/pages/questionnaires/create.tsx
@@ -1,13 +1,12 @@
 import { NextPage } from 'next';
-import { createContext, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { createContext } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { InputChoiceArea } from '../../components/formParts/InputChoiceArea';
-import { InputImage } from '../../components/formParts/InputImage';
+// import { InputImage } from '../../components/formParts/InputImage';
 import { InputTag } from '../../components/formParts/InputTag';
 import { InputText } from '../../components/formParts/InputText';
 import { QreChoice } from '../../domain/models/qreChoice';
 import { StoreQuestionnaireProps } from '../../domain/useCaseProps/questionnaire/storeQuestionnaireProps';
-import { addChoiceListState } from '../../states/atoms/addChoiceListAtom';
 import { addTagListState } from '../../states/atoms/addTagListAtom';
 import { inputDescriptionState } from '../../states/atoms/inputDescriptionAtom';
 import { inputTitleState } from '../../states/atoms/inputTitleAtom';
@@ -17,6 +16,7 @@ import styles from '../../styles/Home.module.scss';
 import form_styles from '../../styles/components/formParts/Form.module.scss';
 import { QuestionnaireUseCase } from '../../usecase/questionnaireUseCase';
 import { validation } from '../../utils/validation';
+import { errorMessageState } from '../../states/atoms/errorMessageAtom';
 
 const questionnaireUseCase = new QuestionnaireUseCase();
 
@@ -34,15 +34,12 @@ const QuestionnaireCreatePage: NextPage = () => {
   // 追加されたタグリストとそのリストに含まれるタグの個数
   const addTagList = useRecoilValue(addTagListState);
 
-  // 選択肢リストのstate
-  const [addChoiceList, setAddChoiceList] = useRecoilState(addChoiceListState);
-
-  const [error, setError] = useState({});
+  // エラーメッセージを更新するセッター関数
+  const setErrorMessage = useSetRecoilState(errorMessageState);
 
   const submitButton = async () => {
     if (Object.keys(validation()).length) {
-      setError(validation());
-      console.log(validation());
+      setErrorMessage(validation());
       return;
     }
 
@@ -55,12 +52,11 @@ const QuestionnaireCreatePage: NextPage = () => {
       tags: addTagList,
     };
 
-    console.log(questionnaire);
-
+    // アンケート登録APIを実行する
     const { data } = await questionnaireUseCase.storeQuestionnaire(questionnaire);
     const message = data.message;
-    console.log(data);
 
+    // TODO: マイページにリダイレクト
     alert(`${message}\nTODO: マイページの自分の作ったアンケート一覧にリダイレクトする予定`);
   };
 
@@ -77,14 +73,6 @@ const QuestionnaireCreatePage: NextPage = () => {
     return newList;
   };
 
-  const errorButton = () => {
-    console.log(error.title);
-  };
-
-  const testButton = () => {
-    console.log(addChoiceList);
-  };
-
   return (
     <>
       <div className={styles.questionnaire_create}>
@@ -95,19 +83,17 @@ const QuestionnaireCreatePage: NextPage = () => {
               <p className={styles.description}>
                 アンケートのタイトルと簡潔な説明を設定してください
               </p>
-              <ErrorMessage.Provider value={ErrorMessage}>
-                <InputText
-                  title="タイトル"
-                  id="title"
-                  name="title"
-                  placeholder="例：目玉焼きには醤油派？ソース派"
-                  maxLength={30}
-                  validationName="タイトル"
-                  inputText={inputTitle}
-                  setInputText={setInputTitle}
-                  inputTextLength={inputTitleLength}
-                />
-              </ErrorMessage.Provider>
+              <InputText
+                title="タイトル"
+                id="title"
+                name="title"
+                placeholder="例：目玉焼きには醤油派？ソース派"
+                maxLength={30}
+                validationName="タイトル"
+                inputText={inputTitle}
+                setInputText={setInputTitle}
+                inputTextLength={inputTitleLength}
+              />
               <InputText
                 title="アンケートのかんたんな説明"
                 id="description"
@@ -152,12 +138,6 @@ const QuestionnaireCreatePage: NextPage = () => {
                 アンケートを公開する
               </button>
             </section>
-            <button className={form_styles.submit_button} onClick={() => errorButton()}>
-              デバッグエラー
-            </button>
-            <button className={form_styles.submit_button} onClick={() => testButton()}>
-              テストボタン
-            </button>
           </div>
         </div>
       </div>

--- a/client/src/repository/repositoryPattern/questionnaireRepository.ts
+++ b/client/src/repository/repositoryPattern/questionnaireRepository.ts
@@ -1,10 +1,13 @@
+import { StoreQuestionnaireProps } from "../../domain/useCaseProps/questionnaire/storeQuestionnaireProps";
 import { $axios } from "../../utils/api";
 
 const BASE_URL = process.env.API_BASE_URL;
+const CLIENT_URL = process.env.NEXT_PUBLIC_API_CLIENT_URL;
 
 export class QuestionnaireRepository {
   /**
    * アンケートランキング一覧取得APIを実行
+   *
    * @param {String} type ランキング種別
    * @param {Number} page 取得ページ番号
    * @param {Number} limit 取得件数
@@ -20,12 +23,23 @@ export class QuestionnaireRepository {
   }
 
   /**
-   * 
+   * アンケート詳細APIを実行
+   *
    * @param {number} questionnaireId 
    * @returns {Object}
    */
   async fetchQuestionnaire(questionnaireId: number) {
     const response = await $axios.get(`${BASE_URL}questionnaires/${questionnaireId}`);
+    return response;
+  }
+
+  /**
+   * アンケート登録APIを実行
+   * @param {StoreQuestionnaireProps} questionnaire 
+   * @returns {Object}
+   */
+  async save(questionnaire: StoreQuestionnaireProps) {
+    const response = await $axios.post(`${CLIENT_URL}questionnaires`, questionnaire);
     return response;
   }
 }

--- a/client/src/repository/repositoryPattern/tagRepository.ts
+++ b/client/src/repository/repositoryPattern/tagRepository.ts
@@ -1,0 +1,19 @@
+import { $axios } from "../../utils/api";
+
+const CLIENT_URL = process.env.NEXT_PUBLIC_API_CLIENT_URL;
+
+export class TagRepository {
+  /**
+   * タグ登録APIを実行
+   * @param {String} name タグ名
+   * @returns {Object}
+   */
+  async storeTag(name: string) {
+
+    const response = await $axios.post(`${CLIENT_URL}tags`,{
+      name: name,
+    });
+
+    return response;
+  }
+}

--- a/client/src/states/atoms/addChoiceListAtom.ts
+++ b/client/src/states/atoms/addChoiceListAtom.ts
@@ -1,0 +1,19 @@
+import { atom } from 'recoil';
+import { QreChoice } from '../../domain/models/qreChoice';
+
+/**
+ * アンケート作成画面で追加されたの選択肢リストの状態を管理するatom
+ */
+export const addChoiceListState = atom<Pick<QreChoice, 'body' | 'displayOrder'>[]>({
+  key: 'addChoiceListState',
+  default: [
+    {
+      body: '',
+      displayOrder: 1,
+    },
+    {
+      body: '',
+      displayOrder: 2,
+    },
+  ],
+});

--- a/client/src/states/atoms/addTagListAtom.ts
+++ b/client/src/states/atoms/addTagListAtom.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+import { Tag } from '../../domain/models/tag';
+
+/**
+ * アンケート作成画面で追加されたのタグリストの状態を管理するatom
+ */
+export const addTagListState = atom<Tag[]>({
+  key: 'addTagListState',
+  default: [],
+});

--- a/client/src/states/atoms/errorMessageAtom.ts
+++ b/client/src/states/atoms/errorMessageAtom.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+
+interface errorMessageProps {
+  [key: string]: string
+}
+
+/**
+ * エラーメッセージを管理するatom
+ */
+export const errorMessageState = atom<errorMessageProps>({
+  key: 'errorMessageState',
+  default: {}
+});

--- a/client/src/states/atoms/inputChoiceAtom.ts
+++ b/client/src/states/atoms/inputChoiceAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+/**
+ * アンケート選択肢のテキストフィールドの状態を管理するatom
+ */
+export const inputChoiceState = atom<string>({
+  key: 'inputChoiceState',
+  default: '',
+});

--- a/client/src/states/atoms/inputDescriptionAtom.ts
+++ b/client/src/states/atoms/inputDescriptionAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+/**
+ * アンケート説明文のテキストフィールドの状態を管理するatom
+ */
+export const inputDescriptionState = atom<string>({
+  key: 'inputDescriptionState',
+  default: '',
+});

--- a/client/src/states/atoms/inputTagAtom.ts
+++ b/client/src/states/atoms/inputTagAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+/**
+ * タグ名のテキストフィールドの状態を管理するatom
+ */
+export const inputTagState = atom<string>({
+  key: 'inputTagState',
+  default: '',
+});

--- a/client/src/states/atoms/inputTitleAtom.ts
+++ b/client/src/states/atoms/inputTitleAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+/**
+ * アンケートタイトルのテキストフィールドの状態を管理するatom
+ */
+export const inputTitleState = atom<string>({
+  key: 'inputTitleState',
+  default: '',
+});

--- a/client/src/states/selectors/addTagListLengthSelector.ts
+++ b/client/src/states/selectors/addTagListLengthSelector.ts
@@ -1,0 +1,13 @@
+import { selector } from "recoil";
+import { addTagListState } from "../atoms/addTagListAtom";
+
+/**
+ * アンケート作成画面で追加されたのタグリストの数を状態を管理するselector
+ */
+export const addTagListLengthState = selector<number>({
+  key: 'addTagListLengthState',
+  get: ({ get }) => {
+    const addTagList = get(addTagListState);
+    return addTagList.length;
+  },
+});

--- a/client/src/states/selectors/inputChoiceLengthSelector.ts
+++ b/client/src/states/selectors/inputChoiceLengthSelector.ts
@@ -1,0 +1,13 @@
+import { selector } from "recoil";
+import { inputChoiceState } from "../atoms/inputChoiceAtom";
+
+/**
+ * アンケート選択肢のテキストフィールドの文字数状態を管理するselector
+ */
+export const inputChoiceLengthState = selector<number>({
+  key: 'inputChoiceLengthState',
+  get: ({ get }) => {
+    const inputChoice = get(inputChoiceState);
+    return inputChoice.length;
+  },
+});

--- a/client/src/states/selectors/inputDescriptionLengthSelector.ts
+++ b/client/src/states/selectors/inputDescriptionLengthSelector.ts
@@ -1,0 +1,13 @@
+import { selector } from "recoil";
+import { inputDescriptionState } from "../atoms/inputDescriptionAtom";
+
+/**
+ * アンケート説明文のテキストフィールドの文字数状態を管理するselector
+ */
+export const inputDescriptionLengthState = selector<number>({
+  key: 'inputDescriptionLengthSelectorState',
+  get: ({ get }) => {
+    const inputDescription = get(inputDescriptionState);
+    return inputDescription.length;
+  },
+});

--- a/client/src/states/selectors/inputTagLengthSelector.ts
+++ b/client/src/states/selectors/inputTagLengthSelector.ts
@@ -1,0 +1,13 @@
+import { selector } from "recoil";
+import { inputTagState } from "../atoms/inputTagAtom";
+
+/**
+ * タグ名のテキストフィールドの文字数状態を管理するselector
+ */
+export const inputTagLengthState = selector<number>({
+  key: 'inputTagLengthState',
+  get: ({ get }) => {
+    const inputTag = get(inputTagState);
+    return inputTag.length;
+  },
+});

--- a/client/src/states/selectors/inputTitleLengthSelector.ts
+++ b/client/src/states/selectors/inputTitleLengthSelector.ts
@@ -1,0 +1,13 @@
+import { selector } from "recoil";
+import { inputTitleState } from "../atoms/inputTitleAtom";
+
+/**
+ * アンケートタイトルのテキストフィールドの文字数状態を管理するselector
+ */
+export const inputTitleLengthState = selector<number>({
+  key: 'inputTitleLengthState',
+  get: ({ get }) => {
+    const inputTitle = get(inputTitleState);
+    return inputTitle.length;
+  },
+});

--- a/client/src/styles/Home.module.scss
+++ b/client/src/styles/Home.module.scss
@@ -325,9 +325,11 @@
     padding: 20px 0;
   }
   h3 {
-    margin-bottom: 16px;
+    margin-bottom: 8px;
   }
   .description {
     margin-bottom: 20px;
+    font-size: 12px;
+    color: #BFBCBC;
   }
 }

--- a/client/src/styles/Home.module.scss
+++ b/client/src/styles/Home.module.scss
@@ -29,7 +29,7 @@
         overflow: hidden;
         border-radius: 8px;
         background: #fff;
-        transition: .2s cubic-bezier(0.445, 0.05, 0.55, 0.95);
+        transition: 0.2s cubic-bezier(0.445, 0.05, 0.55, 0.95);
         @include mq(sm) {
           flex-wrap: wrap;
         }
@@ -118,7 +118,7 @@
       li {
         color: $tag_color;
         &::before {
-          content: "#";
+          content: '#';
         }
       }
     }
@@ -160,7 +160,7 @@
         z-index: 1;
         font-size: 28px;
         font-weight: 900;
-        letter-spacing: -.06em;
+        letter-spacing: -0.06em;
         @include mq(sm) {
           font-size: 26px;
         }
@@ -211,7 +211,7 @@
           padding: 10px 12px;
         }
       }
-      input[type=radio] {
+      input[type='radio'] {
         display: flex;
         align-items: center;
         position: absolute;
@@ -276,30 +276,58 @@
     }
     .choice_button_row {
       margin-top: 20px;
-      padding-bottom: .3em;
+      padding-bottom: 0.3em;
     }
     .choice_button {
       display: block;
       width: 300px;
-      min-height: calc(50px - .3em);
+      min-height: calc(50px - 0.3em);
       background: $main_color;
       border: 0;
       border-radius: 8px;
-      box-shadow: 0 .3em 0 #83c6be;
+      box-shadow: 0 0.3em 0 #83c6be;
       color: #fff;
       font-size: 16px;
       font-weight: bold;
       text-align: center;
       margin: 0 auto;
       &:hover {
-        transform: translateY(.3em);
+        transform: translateY(0.3em);
         box-shadow: none;
       }
       &:disabled {
-        transform: translateY(.3em);
+        transform: translateY(0.3em);
         background: #dadada;
         box-shadow: none;
       }
     }
+  }
+}
+
+/* アンケート（作成画面）
+----------------------------------------------------------------- */
+.questionnaire_create {
+  padding: 16px 8px;
+  .content_inner {
+    width: 1024px;
+    max-width: 100%;
+    margin: 0 auto;
+    border-radius: 8px;
+    background: #fff;
+  }
+  .questionnaire_container {
+    width: 768px;
+    max-width: 98%;
+    margin: 0 auto;
+    padding: 24px 0;
+  }
+  .questionnaire_section {
+    padding: 20px 0;
+  }
+  h3 {
+    margin-bottom: 16px;
+  }
+  .description {
+    margin-bottom: 20px;
   }
 }

--- a/client/src/styles/components/formParts/Form.module.scss
+++ b/client/src/styles/components/formParts/Form.module.scss
@@ -1,0 +1,86 @@
+@use '../../variables.scss' as *;
+@use '../../mixin.scss' as *;
+
+.input_row {
+  margin-bottom: 20px;
+}
+
+.text_label {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.text_count {
+  font-size: 12px;
+  color: #bfbcbc;
+}
+
+.form_parts {
+  &.input {
+    display: block;
+    width: 100%;
+    padding: 8px;
+    border-radius: 2px;
+    border: 2px solid $base_border_color;
+    background: #fff;
+    font-size: 14px;
+    @include placeholder {
+      font-size: 14px;
+      color: #757575;
+    }
+    &.-short {
+      max-width: 300px;
+    }
+    &:disabled {
+      background: $base_border_color;
+    }
+  }
+}
+
+// タグ登録フォーム
+.tags {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    color: $tag_color;
+    background: $tag_bg_color;
+  }
+  .tag_remove {
+    display: inline-block;
+    position: relative;
+    width: 10px;
+    height: 10px;
+    margin-left: 8px;
+    padding: 7px;
+    border: 1px solid $tag_color;
+    line-height: 1;
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 7px;
+      height: 1px;
+      background: $tag_color;
+      transform: translate(-50%, -50%) rotate(45deg);
+    }
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 7px;
+      height: 1px;
+      background: $tag_color;
+      transform: translate(-50%, -50%) rotate(-45deg);
+    }
+  }
+}

--- a/client/src/styles/components/formParts/Form.module.scss
+++ b/client/src/styles/components/formParts/Form.module.scss
@@ -5,6 +5,8 @@
   margin-bottom: 20px;
 }
 
+/* ラベル
+----------------------------------------------------------------- */
 .text_label {
   display: flex;
   justify-content: space-between;
@@ -17,29 +19,52 @@
   color: #bfbcbc;
 }
 
+.image_label {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid $tag_color;
+  border-radius: 4px;
+  padding: 6px;
+  color: $tag_color;
+  svg[data-icon='file-image'] {
+    margin-right: 5px;
+    font-size: 16px;
+  }
+}
+
+/* フォームパーツ
+----------------------------------------------------------------- */
 .form_parts {
-  &.input {
+  // テキストフィールド
+  &.input_text {
     display: block;
     width: 100%;
     padding: 8px;
     border-radius: 2px;
-    border: 2px solid $base_border_color;
+    border: 1px solid $base_border_color;
     background: #fff;
     font-size: 14px;
     @include placeholder {
       font-size: 14px;
       color: #757575;
     }
-    &.-short {
-      max-width: 300px;
-    }
     &:disabled {
       background: $base_border_color;
     }
   }
+  // ファイル投稿フォーム
+  &.input_image {
+    display: none;
+  }
 }
 
-// タグ登録フォーム
+/* タグ登録フォーム
+----------------------------------------------------------------- */
+.tag_form {
+  max-width: 300px;
+}
+
 .tags {
   display: flex;
   gap: 8px;
@@ -82,5 +107,44 @@
       background: $tag_color;
       transform: translate(-50%, -50%) rotate(-45deg);
     }
+  }
+}
+
+/* 設問登録
+----------------------------------------------------------------- */
+.choice_create {
+  padding: 8px;
+  border: 1px solid $base_text_color;
+  background: $light_bg_color;
+}
+
+/* 送信ボタン
+----------------------------------------------------------------- */
+.submit_button {
+  display: block;
+  width: 100%;
+  padding: 16px;
+  border-radius: 4px;
+  border: 2px solid $tag_color;
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+  color: $tag_color;
+  transition: all 0.1s linear;
+  &:hover {
+    background: $tag_color;
+    color: #fff;
+
+  }
+}
+
+/* エラーメッセージ
+----------------------------------------------------------------- */
+.error_area {
+  display: block;
+  padding: 8px;
+  background: #f1a6a6;
+  .error_text {
+    color: #b42424;
   }
 }

--- a/client/src/styles/globals.scss
+++ b/client/src/styles/globals.scss
@@ -168,3 +168,13 @@ h5 {
 .hidden {
   display: none !important;
 }
+
+/* フォーム
+----------------------------------------------------------------- */
+input[type='text'] {
+  &.validate-text {
+    &.error {
+      border: 1px solid #ff6767;
+    }
+  }
+}

--- a/client/src/styles/mixin.scss
+++ b/client/src/styles/mixin.scss
@@ -1,0 +1,5 @@
+@mixin placeholder {
+  &::placeholder {@content;}
+  &:-ms-input-placeholder {@content;}
+  &::-ms-input-placeholder {@content;}
+}

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -4,12 +4,14 @@ $main_color: #95DFD6;
 // $main_color: #CDF0EA;候補2
 // $main_color: #abe9e1;候補3
 // $accent_color: #EAA8BF;
+
 $vote_color-1: #ECACB5;
 $vote_color-2: #99CFE5;
 $tag_color: #3B5998;
 $tag_bg_color: #dfe9ff;
 
 $body_bg_color: $main_color;
+$light_bg_color: #eafffc;
 $header_bg_color: #fff;
 $footer_bg_color: #fff;
 

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -7,12 +7,15 @@ $main_color: #95DFD6;
 $vote_color-1: #ECACB5;
 $vote_color-2: #99CFE5;
 $tag_color: #3B5998;
+$tag_bg_color: #dfe9ff;
 
 $body_bg_color: $main_color;
 $header_bg_color: #fff;
 $footer_bg_color: #fff;
 
 $base_text_color: #333;
+
+$base_border_color: #ddd;
 
 /* Common
 ----------------------------------------------------------------- */

--- a/client/src/tsconfig.json
+++ b/client/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/client/src/usecase/questionnaireUseCase.ts
+++ b/client/src/usecase/questionnaireUseCase.ts
@@ -1,3 +1,6 @@
+import { QreChoice } from "../domain/models/qreChoice";
+import { Tag } from "../domain/models/tag";
+import { StoreQuestionnaireProps } from "../domain/useCaseProps/questionnaire/storeQuestionnaireProps";
 import { QuestionnaireRepository } from "../repository/repositoryPattern/questionnaireRepository";
 
 export class QuestionnaireUseCase {
@@ -12,6 +15,7 @@ export class QuestionnaireUseCase {
 
   /**
    * アンケートのランキング一覧を取得する
+   *
    * @param {String} type ランキング種別
    * @param {Number} page 取得ページ番号
    * @param {Number} limit 取得件数
@@ -22,11 +26,22 @@ export class QuestionnaireUseCase {
   }
 
   /**
-   * 
+   * アンケート詳細を取得する
+   *
    * @param {number} questionnaireId 
    * @returns {Object}
    */
   getQuestionnaire(questionnaireId: number) {
     return this.questionnaireRepository.fetchQuestionnaire(questionnaireId);
+  }
+
+  /**
+   * アンケートを新規登録する
+   *
+   * @param {StoreQuestionnaireProps} questionnaire
+   * @returns 
+   */
+  storeQuestionnaire(questionnaire: StoreQuestionnaireProps) {
+    return this.questionnaireRepository.save(questionnaire);
   }
 }

--- a/client/src/usecase/tagUseCase.ts
+++ b/client/src/usecase/tagUseCase.ts
@@ -1,0 +1,23 @@
+import { TagRepository } from "../repository/repositoryPattern/tagRepository";
+
+export class TagUseCase {
+  private tagRepository: TagRepository;
+
+  /**
+   * コンストラクタ
+   */
+  constructor() {
+    this.tagRepository = new TagRepository;
+  }
+
+  /**
+   * タグ名が既に存在していればそのタグ情報をDBから取得、
+   * 存在しない場合、タグ登録をする
+   *
+   * @param {String} name タグ名
+   * @returns {Object}
+   */
+  async postTag(name: string) {
+    return await this.tagRepository.storeTag(name);
+  }
+}

--- a/client/src/utils/arrayUtils.ts
+++ b/client/src/utils/arrayUtils.ts
@@ -1,0 +1,15 @@
+// オブジェクトの配列の重複をチェックする
+export const detectDuplicates = (array: object[]) => {
+  // 重複をチェックするために、配列内のオブジェクトを文字列に変換する
+  const stringArray = array.map(JSON.stringify);
+
+  // Setを使用して重複を削除する
+  const uniqueArray = new Set(stringArray);
+
+  // 重複があった場合、配列のサイズが異なる
+  if (stringArray.length !== uniqueArray.size) {
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/client/src/utils/validation.ts
+++ b/client/src/utils/validation.ts
@@ -1,0 +1,19 @@
+export const validation = () => {
+  const targetList = [...document.querySelectorAll('.validate-text')];
+
+  let message = {};
+
+  // 空の入力欄チェック
+  targetList.map((target) => {
+    if (target.value.trim() === '') {
+      message[target.getAttribute('name')] =`${target.dataset.validationName}を入力してください`;
+      target.classList.add('error');
+    }
+  })
+
+  return message;
+}
+
+export const removeError = (target) => {
+  target.classList.remove('error');
+}

--- a/client/src/utils/validation.ts
+++ b/client/src/utils/validation.ts
@@ -1,19 +1,20 @@
-export const validation = () => {
-  const targetList = [...document.querySelectorAll('.validate-text')];
+export const validation = (): { [key: string]: string } => {
 
-  let message = {};
+  let errorMessage: { [key: string]: string } = {};
+
+  const targetList = [...document.querySelectorAll('.validate-text')] as HTMLInputElement[];
 
   // 空の入力欄チェック
   targetList.map((target) => {
     if (target.value.trim() === '') {
-      message[target.getAttribute('name')] =`${target.dataset.validationName}を入力してください`;
+      errorMessage[target.getAttribute('name') as string] = `${target.dataset.validationName}を入力してください`;
       target.classList.add('error');
     }
   })
 
-  return message;
+  return errorMessage;
 }
 
-export const removeError = (target) => {
+export const removeError = (target: HTMLElement) => {
   target.classList.remove('error');
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
         source: ./docker/db/sql
         target: /docker-entrypoint-initdb.d
       - type: bind
-        source: ./docker/db/my.conf
-        target: /etc/mysql/conf.d/my.conf
+        source: ./docker/db/my.cnf
+        target: /etc/mysql/conf.d/my.cnf
       - mysql-volume:/var/lib/mysql
     networks:
       survey-factory_net:

--- a/docker/db/my.cnf
+++ b/docker/db/my.cnf
@@ -2,8 +2,7 @@
 # character
 skip-character-set-client-handshake
 character-set-server = utf8mb4
-# collation-server = utf8mb4_general_ci
-collation-server = utf8mb4_unicode_ci
+collation-server = utf8mb4_ja_0900_as_cs_ks
 init-connect = SET NAMES utf8mb4
 
 # timezone
@@ -11,17 +10,17 @@ default-time-zone = SYSTEM
 log_timestamps = SYSTEM
 
 # Error Log
-log-error = mysql-error.log
+log-error = /var/log/mysql/mysql-error.log
 
 # Slow Query Log
 slow_query_log = 1
-slow_query_log_file = mysql-slow.log
+slow_query_log_file = /var/log/mysql/mysql-slow.log
 long_query_time = 1.0
 log_queries_not_using_indexes = 0
 
 # General Log
 general_log = 1
-general_log_file = mysql-general.log
+general_log_file = /var/log/mysql/mysql-general.log
 
 [client]
 default-character-set=utf8mb4

--- a/document/api/openapi.yaml
+++ b/document/api/openapi.yaml
@@ -207,8 +207,8 @@ paths:
                   value:
                     message:
                       userId: ユーザーIDは整数で指定してください。
-                      title: タイトルは、255文字以下で指定してください。
-                      description: アンケートの説明は必ず指定してください。
+                      title: タイトルは、30文字以下で指定してください。
+                      description: アンケートの説明は50文字以下で指定してください。
                       thumbnailUrl: サムネイルに正しい形式を指定してください。
                       qreChoices:
                         body: 選択肢は必ず指定してください。
@@ -265,7 +265,6 @@ paths:
               required:
                 - userId
                 - title
-                - description
                 - qreChoices
                 - tags
             examples:
@@ -302,11 +301,11 @@ paths:
         - アンケート
   '/api/v1/questionnaires/{questionnaireId}':
     get:
-      summary: アンケートプレイ画面詳細取得
+      summary: アンケート詳細取得
       operationId: get-api-v1-questionnaires-questionnaireId
       responses:
         '200':
-          description: アンケートプレイ画面詳細の返却成功
+          description: アンケート詳細の返却成功
           content:
             application/json:
               schema:


### PR DESCRIPTION
## タスクのリンク
https://www.notion.so/Table-d4e453638ca3402d80ea87385df80141

## やったこと
- データベースの照合順序(collation)設定の変更
- Recoil状態管理ライブラリ導入
- アンケート登録フロント機能実装
- フロントバリデーション実装

## やらないこと
- アンケート作成後のマイページへのリダイレクト

## 動作確認
- ブラウザ動作確認

https://user-images.githubusercontent.com/50767102/218633480-dcdf9ea2-da71-4331-b1a2-9ccf7810f73a.mov

## 特にレビューをお願いしたい箇所
- 編集途中でページ遷移してもフィールドにテキストがのこらないか

## その他
なし
