### PR TITLE
SF-031 CSS追記＆投票済ステート関連のコード諸々修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ remake:
 	@make up
 
 create-network:
-	@docker network create survey-factory_net
+	-@docker network create survey-factory_net
 
 ps:
 	docker ps -a

--- a/client/src/components/formParts/InputTag.tsx
+++ b/client/src/components/formParts/InputTag.tsx
@@ -1,0 +1,114 @@
+import { useEffect } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { Tag } from '../../domain/models/tag';
+import { addTagListState } from '../../states/atoms/addTagListAtom';
+import { inputTagState } from '../../states/atoms/inputTagAtom';
+import { addTagListLengthState } from '../../states/selectors/addTagListLengthSelector';
+import { inputTagLengthState } from '../../states/selectors/inputTagLengthSelector';
+import styles from '../../styles/components/formParts/Form.module.scss';
+import { TagUseCase } from '../../useCase/tagUseCase';
+import { detectDuplicates } from '../../utils/arrayUtils';
+
+interface InputTagProps {
+  title: string;
+  id: string;
+  name: string;
+  placeholder: string;
+  maxLength: number;
+}
+
+const tagUseCase = new TagUseCase();
+
+export const InputTag: React.FC<InputTagProps> = ({ title, id, name, placeholder, maxLength }) => {
+  // タグ名のテキストフィールドと文字数のstate
+  const [inputTag, setInputTag] = useRecoilState(inputTagState);
+  const inputTagLength = useRecoilValue(inputTagLengthState);
+
+  // 追加されたタグリストとそのリストに含まれるタグの個数
+  const [addTagList, setAddTagList] = useRecoilState(addTagListState);
+  const addTagListLength = useRecoilValue(addTagListLengthState);
+
+  // 初期化
+  useEffect(() => {
+    if (addTagList.length === 0) {
+      setInputTag('');
+    }
+  }, [addTagList]);
+
+  // テキスト入力時のイベント
+  const handleInputChange = (e: any) => {
+    // 最大文字数に達していない場合のみ入力を反映
+    if (e.target.value.length <= maxLength) {
+      setInputTag(e.target.value);
+    }
+  };
+
+  // エンターキー押下時タグを登録
+  const handleSubmit = async (e: any) => {
+    e.preventDefault();
+
+    /*
+     * 1. リストが既に3つ以上の場合は登録しない
+     * 2. タグ名入力欄が空の場合は登録しない
+     */
+    if (addTagListLength >= 3 || inputTag === '') {
+      return;
+    }
+
+    const { data } = await tagUseCase.postTag(inputTag);
+
+    let newTagList: Tag[] = [...addTagList, data];
+
+    if (detectDuplicates(newTagList)) {
+      newTagList = [...addTagList];
+      setInputTag('');
+      return;
+    }
+
+    setInputTag('');
+    setAddTagList(newTagList);
+  };
+
+  const removeTag = (id: number) => {
+    setAddTagList((tagList) => {
+      return tagList.filter((tag) => tag.id !== id);
+    });
+  };
+
+  return (
+    <div className={styles.input_row}>
+      <form className={styles.tag_form} onSubmit={handleSubmit}>
+        <label htmlFor={id} className={styles.text_label}>
+          {title}
+          <span className={styles.text_count}>
+            {inputTagLength}/{maxLength}
+          </span>
+        </label>
+        <input
+          type="text"
+          id={id}
+          className={`${styles.form_parts} ${styles.input_text}`}
+          name={name}
+          placeholder={addTagListLength >= 3 ? '3つ設定済み' : placeholder}
+          maxLength={maxLength}
+          value={inputTag}
+          disabled={addTagListLength >= 3}
+          onChange={handleInputChange}
+        />
+      </form>
+      <div className={styles.tags}>
+        {addTagList.map((tag, key) => (
+          <span className={styles.tag} id={`tag_${tag.id}`} key={key}>
+            <span># {tag.name}</span>
+            <a
+              href="#"
+              className={styles.tag_remove}
+              title={`${tag.name}タグを削除`}
+              onClick={() => removeTag(tag.id)}
+            ></a>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/questionnaires/Result.tsx
+++ b/client/src/components/questionnaires/Result.tsx
@@ -1,24 +1,26 @@
 import { NextPage } from 'next';
+import { QreChoice } from '../../domain/models/qreChoice';
 import { Questionnaire } from '../../domain/models/questionnaire';
 import styles from '../../styles/Home.module.scss';
 
 type Result = {
   questionnaire: Questionnaire;
-  voteCount: number[];
+  qreChoices: Omit<QreChoice, 'displayOrder'>[];
 };
 
-const Result: NextPage<Result> = ({ voteCount, questionnaire }) => {
+const Result: NextPage<Result> = ({ questionnaire, qreChoices }) => {
   return (
     <div className={styles.result}>
       <div className={styles.result_bar}>
-        {voteCount.map((count: number, key) => (
+        {qreChoices.map((qreChoice: Omit<QreChoice, 'displayOrder'>, key: number) => (
           <div
-            className={styles.result_num}
-            style={{ width: (count / questionnaire.voteCountAll) * 100 + '%' }}
-            key={key}
+          className={styles.result_num}
+          style={{ width: (qreChoice.voteCount / questionnaire.voteCountAll) * 100 + '%' }}
+          key={key}
           >
+            <span className={styles.result_text}>{qreChoices[key].body}</span>
             <span className={styles.number}>
-              {Math.round((count / questionnaire.voteCountAll) * 1000) / 10}
+              {Math.round((qreChoice.voteCount / questionnaire.voteCountAll) * 1000) / 10}
               <span className={styles.percent}>%</span>
             </span>
           </div>

--- a/client/src/env.local
+++ b/client/src/env.local
@@ -1,0 +1,2 @@
+API_BASE_URL=http://nginx:80/api/v1/
+NEXT_PUBLIC_API_CLIENT_URL=http://localhost:8080/api/v1/

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import styles from '../styles/Home.module.scss';
 import { Questionnaire } from '../domain/models/questionnaire';
 import { Pager } from '../domain/models/pager';
-import { QuestionnaireUseCase } from '../usecase/questionnaireUseCase';
+import { QuestionnaireUseCase } from '../useCase/questionnaireUseCase';
 
 type HomePage = {
   questionnaires: Questionnaire[];
@@ -22,7 +22,7 @@ const Home: NextPage<HomePage> = ({ questionnaires }) => {
           <h2 className={styles.heading_main}>ランキング</h2>
           <div className={styles.ranking}>
             <ul className={styles.ranking_list}>
-              {questionnaires.map((questionnaire, key) => (
+              {questionnaires.map((questionnaire, key: number) => (
                 <li key={key}>
                   <Link href={`/questionnaires/${questionnaire.id}`}>
                     <div className={styles.thumbnail}>

--- a/client/src/pages/questionnaires/create.tsx
+++ b/client/src/pages/questionnaires/create.tsx
@@ -1,0 +1,192 @@
+import { NextPage } from 'next';
+import { createContext, useEffect } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { InputChoiceArea } from '../../components/formParts/InputChoiceArea';
+// import { InputImage } from '../../components/formParts/InputImage';
+import { InputTag } from '../../components/formParts/InputTag';
+import { InputText } from '../../components/formParts/InputText';
+import { QreChoice } from '../../domain/models/qreChoice';
+import { StoreQuestionnaireProps } from '../../domain/useCaseProps/questionnaire/storeQuestionnaireProps';
+import { addTagListState } from '../../states/atoms/addTagListAtom';
+import { inputDescriptionState } from '../../states/atoms/inputDescriptionAtom';
+import { inputTitleState } from '../../states/atoms/inputTitleAtom';
+import { inputDescriptionLengthState } from '../../states/selectors/inputDescriptionLengthSelector';
+import { inputTitleLengthState } from '../../states/selectors/inputTitleLengthSelector';
+import styles from '../../styles/Home.module.scss';
+import form_styles from '../../styles/components/formParts/Form.module.scss';
+import { QuestionnaireUseCase } from '../../useCase/questionnaireUseCase';
+import { validation } from '../../utils/validation';
+import { errorMessageState } from '../../states/atoms/errorMessageAtom';
+import { addChoiceListState } from '../../states/atoms/addChoiceListAtom';
+
+const questionnaireUseCase = new QuestionnaireUseCase();
+
+export const ErrorMessage = createContext({});
+
+const QuestionnaireCreatePage: NextPage = () => {
+  // タイトルのテキストフィールドと文字数のstate
+  const [inputTitle, setInputTitle] = useRecoilState(inputTitleState);
+  const inputTitleLength = useRecoilValue(inputTitleLengthState);
+
+  // 説明文のテキストフィールドと文字数のstate
+  const [inputDescription, setInputDescription] = useRecoilState(inputDescriptionState);
+  const inputDescriptionLength = useRecoilValue(inputDescriptionLengthState);
+
+  // 追加されたタグリストとそのリストに含まれるタグの個数
+  const [addTagList, setAddTagList] = useRecoilState(addTagListState);
+
+  // 選択肢配列のstateのセッター関数
+  const setAddChoiceList = useSetRecoilState(addChoiceListState);
+
+  // エラーメッセージを更新するセッター関数
+  const setErrorMessage = useSetRecoilState(errorMessageState);
+
+  // recoilで管理してるフィールドの初期化
+  useEffect(() => {
+    setInputTitle('');
+    setInputDescription('');
+    setAddTagList([]);
+    setAddChoiceList([
+      {
+        body: '',
+        displayOrder: 1,
+      },
+      {
+        body: '',
+        displayOrder: 2,
+      },
+    ]);
+    setErrorMessage({});
+  }, []);
+
+  const submitButton = async () => {
+    if (Object.keys(validation()).length) {
+      setErrorMessage(validation());
+      return;
+    }
+
+    const questionnaire: StoreQuestionnaireProps = {
+      userId: 11,
+      title: inputTitle,
+      description: inputDescription,
+      thumbnailUrl: '',
+      qreChoices: setChoices(),
+      tags: addTagList,
+    };
+
+    // アンケート登録APIを実行する
+    const { data } = await questionnaireUseCase.storeQuestionnaire(questionnaire);
+    const message = data.message;
+
+    // RecoilのStateをリセットする
+    recoilStateReset();
+
+    // TODO: マイページにリダイレクト
+    alert(`${message}\nTODO: マイページの自分の作ったアンケート一覧にリダイレクトする予定`);
+  };
+
+  // アンケートSubmit後、選択肢のオブジェクトを生成する
+  const setChoices = (): Omit<QreChoice, 'id' | 'voteCount'>[] => {
+    const choices = [...document.querySelectorAll('input[name^=choice]')] as HTMLInputElement[];
+
+    const newList = choices.map((choice, index) => {
+      return {
+        body: choice.value,
+        displayOrder: index + 1,
+      };
+    });
+
+    return newList;
+  };
+
+  // アンケートSubmiｔ完了後、RecoilのStateをリセットする
+  const recoilStateReset = () => {
+    setInputTitle('');
+    setInputDescription('');
+    setAddTagList([]);
+    setAddChoiceList([
+      {
+        body: '',
+        displayOrder: 1,
+      },
+      {
+        body: '',
+        displayOrder: 2,
+      },
+    ]);
+    setErrorMessage({});
+  };
+
+  return (
+    <>
+      <div className={styles.questionnaire_create}>
+        <div className={styles.content_inner}>
+          <div className={styles.questionnaire_container}>
+            <section className={styles.questionnaire_section}>
+              <h3>アンケートのタイトル</h3>
+              <p className={styles.description}>
+                アンケートのタイトルと簡潔な説明を設定してください
+              </p>
+              <InputText
+                title="タイトル"
+                id="title"
+                name="title"
+                placeholder="例：目玉焼きには醤油派？ソース派"
+                maxLength={30}
+                validationName="タイトル"
+                inputText={inputTitle}
+                setInputText={setInputTitle}
+                inputTextLength={inputTitleLength}
+              />
+              <InputText
+                title="アンケートのかんたんな説明"
+                id="description"
+                name="description"
+                placeholder="例：目玉焼きにかける調味料は醤油が好き？それともソースが好き？"
+                maxLength={50}
+                validationName="アンケート説明文"
+                inputText={inputDescription}
+                setInputText={setInputDescription}
+                inputTextLength={inputDescriptionLength}
+              />
+            </section>
+            <section className={styles.questionnaire_section}>
+              <h3>タグを設定</h3>
+              <p className={styles.description}>アンケートに設定するタグを3つまで設定できます</p>
+              <InputTag
+                title="タグ"
+                id="tagName"
+                name="tagName"
+                placeholder="例：アニメ クレヨンしんちゃん 映画"
+                maxLength={20}
+              />
+            </section>
+            {/* <section className={styles.questionnaire_section}>
+              <h3>サムネイル</h3>
+              <p className={styles.description}>SNSにシェアされたとき表示される画像を設定できます</p>
+              <InputImage
+                title="サムネイル画像をアップロードする"
+                id="thumbnail"
+                name="thumbnail"
+              />
+            </section> */}
+            <section className={styles.questionnaire_section}>
+              <h3>選択肢を追加</h3>
+              <p className={styles.description}>
+                アンケートの設問に対する選択肢を追加してください。
+              </p>
+              <InputChoiceArea title="選択肢を追加" />
+            </section>
+            <section className={styles.questionnaire_section}>
+              <button className={form_styles.submit_button} onClick={() => submitButton()}>
+                アンケートを公開する
+              </button>
+            </section>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default QuestionnaireCreatePage;

--- a/client/src/styles/Home.module.scss
+++ b/client/src/styles/Home.module.scss
@@ -1,5 +1,6 @@
 @use './common.scss';
 @use './variables.scss' as *;
+@use './mixin.scss' as *;
 
 /* main visual
 ----------------------------------------------------------------- */
@@ -52,6 +53,7 @@
           height: 140px;
         }
         p {
+          @include fontRound;
           font-size: 16px;
           font-weight: bold;
         }
@@ -59,6 +61,7 @@
       .detail {
         padding: 16px;
         .title {
+          @include fontRound;
           font-size: 14px;
           font-weight: bold;
           margin-bottom: 10px;
@@ -138,16 +141,16 @@
   /* 棒グラフ */
   .result {
     margin: 50px 0;
-    padding: 0 90px;
     @include mq(sm) {
-      padding: 0 70px;
+      margin: 60px 0 40px;
     }
     .result_bar {
       display: flex;
       justify-content: space-between;
-      width: 500px;
+      position: relative;
+      width: 600px;
       max-width: 100%;
-      height: 30px;
+      height: 35px;
       margin: 0 auto;
     }
     .result_num {
@@ -155,15 +158,25 @@
       align-items: center;
       position: relative;
       height: 100%;
-      .number {
+      .result_text {
+        @include fontRound;
         position: absolute;
+        bottom: 100%;
         z-index: 1;
-        font-size: 28px;
+        font-size: 16px;
         font-weight: 900;
         letter-spacing: -.06em;
         @include mq(sm) {
-          font-size: 26px;
+          font-size: 12px;
         }
+      }
+      .number {
+        @include fontRound;
+        position: absolute;
+        z-index: 1;
+        font-size: 22px;
+        font-weight: 900;
+        letter-spacing: -.06em;
         .percent {
           font-size: 12px;
           font-weight: 900;
@@ -174,29 +187,34 @@
     }
     .result_num:nth-of-type(1) {
       background: $vote_color-1;
-      .number {
-        right: 100%;
+      border-radius: 8px 0 0 8px;
+      .result_text {
+        left: 5px;
         color: $vote_color-1;
-        margin-right: 10px;
-        @include mq(sm) {
-          margin-right: 5px;
-        }
+      }
+      .number {
+        left: 5px;
+        color: #fff;
       }
     }
     .result_num:nth-of-type(2) {
       background: $vote_color-2;
-      .number {
-        left: 100%;
+      border-radius: 0 8px 8px 0;
+      .result_text {
+        right: 5px;
         color: $vote_color-2;
-        margin-left: 10px;
-        @include mq(sm) {
-          margin-left: 5px;
-        }
+      }
+      .number {
+        right: 5px;
+        color: #fff;
       }
     }
   }
-  /* 投票ボタン */
+  /* 投票選択肢 */
   .choices {
+    width: 600px;
+    max-width: 100%;
+    margin: auto;
     .choice_row {
       &:not(:first-child) {
         margin-top: 5px;
@@ -205,10 +223,10 @@
         display: block;
         position: relative;
         z-index: 1;
-        padding: 16px 8px;
+        padding: 16px 16px 16px 40px;
         cursor: pointer;
-        @include mq(sm) {
-          padding: 10px 12px;
+        &.voted {
+          padding: 8px 16px;
         }
       }
       input[type=radio] {
@@ -234,6 +252,9 @@
               height: 16px;
             }
           }
+        }
+        &.voted {
+          background: #e0fdfd;
         }
       }
       .outer {
@@ -265,41 +286,46 @@
         }
       }
       .choice_body {
-        padding: 0 0 0 32px;
+        @include fontRound;
+        font-size: 16px;
       }
       .choice_number_text {
+        @include fontRound;
         font-weight: bold;
         text-align: right;
         color: #1ca7a7;
         margin-top: 5px;
       }
     }
-    .choice_button_row {
-      margin-top: 20px;
-      padding-bottom: .3em;
+  }
+
+  /* 投票ボタン */
+  .choice_button_row {
+    margin-top: 20px;
+    padding-bottom: .3em;
+  }
+  .choice_button {
+    @include fontRound;
+    display: block;
+    width: 300px;
+    min-height: calc(50px - .3em);
+    background: $main_color;
+    border: 0;
+    border-radius: 8px;
+    box-shadow: 0 .3em 0 #83c6be;
+    color: #fff;
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
+    margin: 0 auto;
+    &:hover {
+      transform: translateY(.3em);
+      box-shadow: none;
     }
-    .choice_button {
-      display: block;
-      width: 300px;
-      min-height: calc(50px - .3em);
-      background: $main_color;
-      border: 0;
-      border-radius: 8px;
-      box-shadow: 0 .3em 0 #83c6be;
-      color: #fff;
-      font-size: 16px;
-      font-weight: bold;
-      text-align: center;
-      margin: 0 auto;
-      &:hover {
-        transform: translateY(.3em);
-        box-shadow: none;
-      }
-      &:disabled {
-        transform: translateY(.3em);
-        background: #dadada;
-        box-shadow: none;
-      }
+    &:disabled {
+      transform: translateY(.3em);
+      background: #dadada;
+      box-shadow: none;
     }
   }
 }

--- a/client/src/styles/components/layouts/Header.module.scss
+++ b/client/src/styles/components/layouts/Header.module.scss
@@ -1,4 +1,5 @@
 @use '../../variables.scss' as *;
+@use '../../mixin.scss' as *;
 
 .header {
   background: $header_bg_color;
@@ -17,6 +18,7 @@
   }
 
   .header_nav_button {
+    @include fontRound;
     display: flex;
     align-items: center;
     height: 48px;

--- a/client/src/styles/globals.scss
+++ b/client/src/styles/globals.scss
@@ -1,4 +1,5 @@
 @use './variables.scss' as *;
+@use './mixin.scss' as *;
 
 /* Reset
 ----------------------------------------------------------------- */
@@ -19,7 +20,7 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: $base_font-family-round;
+  font-family: $base_font-family;
   font-size: 14px;
   line-height: 1.5;
   color: $base_text_color;
@@ -45,6 +46,7 @@ h3,
 h4,
 h5,
 h6 {
+  @include fontRound;
   font-weight: bold;
   margin: 0;
 }

--- a/client/src/styles/mixin.scss
+++ b/client/src/styles/mixin.scss
@@ -1,0 +1,7 @@
+@use './variables.scss' as *;
+
+//フォント 丸ゴ
+@mixin fontRound {
+  font-family: $round_font-family;
+  transform: rotateZ(0.03deg);//Windowsでのフォント崩れ対策
+}

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -1,9 +1,6 @@
 /* カラー
 ----------------------------------------------------------------- */
 $main_color: #95DFD6;
-// $main_color: #CDF0EA;候補2
-// $main_color: #abe9e1;候補3
-// $accent_color: #EAA8BF;
 $vote_color-1: #ECACB5;
 $vote_color-2: #99CFE5;
 $tag_color: #3B5998;
@@ -23,7 +20,7 @@ $box_shadow_common: 0 2px 8px #5e5d406b;
 /* base font
 ----------------------------------------------------------------- */
 $base_font-family: 'Noto Sans JP', sans-serif;
-$base_font-family-round: 'M PLUS Rounded 1c', sans-serif;
+$round_font-family: 'M PLUS Rounded 1c', sans-serif;
 
 // Web Fonts
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap');

--- a/client/src/utils/arrayUtils.ts
+++ b/client/src/utils/arrayUtils.ts
@@ -1,0 +1,5 @@
+// オブジェクトの配列の重複をチェックする
+export const detectDuplicates = (array: object[]) => {
+  // Set を使用して重複を削除し、元の配列との要素数を比較する
+  return new Set(array.map(JSON.stringify)).size !== array.length;
+};

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,7 +43,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/db/Dockerfile
-    platform: linux/amd64 # M1チップの場合はコメントアウトを外す
+    # platform: linux/amd64 # M1チップの場合はコメントアウトを外す
     ports:
       - 3306:3306
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/db/Dockerfile
-    platform: linux/amd64 # M1チップの場合はコメントアウトを外す
+    # platform: linux/amd64 # M1チップの場合はコメントアウトを外す
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
## タスクのリンク
- https://www.notion.so/CSS-c3edf620165245b2a92ce88e344c3ca9?pvs=4)

## やったこと
- アンケート投票・結果ページ一部UI変更・CSS追記
- 投票済みステートを使用していた部分のコードを諸々修正・簡略化
- docker関連のコード修正を反映

## やらないこと
- 他、UIデザイン（考え中）
- アンケート作成ページこれから確認していきます。

## 動作確認
- ブラウザ表示↓


## 特にレビューをお願いしたい箇所
- 

## その他
-投票ページにある 「投票後結果が表示されます」の表示は残したままの方が良いでしょうか？表示をわかりやすくするために一時的にダミーで置いているだけかと思い一応残していましたので確認したいです！
